### PR TITLE
Added qvm-convert-pdf manpage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 rpm/
 deb/
 pkgs/
+*.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ sudo: required
 dist: trusty
 language: generic
 install: git clone https://github.com/QubesOS/qubes-builder ~/qubes-builder
-# debootstrap in trusty is old...
-before_script: sudo ln -s sid /usr/share/debootstrap/scripts/stretch
 script: ~/qubes-builder/scripts/travis-build
 env:
  - DIST_DOM0=fc20 USE_QUBES_REPO_VERSION=3.1

--- a/Makefile
+++ b/Makefile
@@ -74,8 +74,10 @@ update-repo-installer:
 	ln -f $(RPMS_DIR)/x86_64/qubes-pdf-converter-dom0-*$(VERSION)*.rpm ../installer/yum/qubes-dom0/rpm/
 
 build:
+	make manpages -C doc
 
 install-vm:
+	make install -C doc
 	install -D -m 0644 qubes.PdfConvert $(DESTDIR)/etc/qubes-rpc/qubes.PdfConvert
 	install -D qvm-convert-pdf $(DESTDIR)/usr/bin/qvm-convert-pdf
 	install -D qpdf-convert-client $(DESTDIR)/usr/lib/qubes/qpdf-convert-client

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: qubes-pdf-converter
 Section: admin
 Priority: extra
 Maintainer: Jason Mehring <nrgaway@gmail.com>
-Build-Depends: debhelper (>= 9~), dh-python, python-all (>= 2.6.6-3~), python-setuptools, quilt
+Build-Depends: debhelper (>= 9~), dh-python, pandoc, python-all (>= 2.6.6-3~), python-setuptools, quilt
 X-Python-Version: 2.7
 Standards-Version: 3.9.5
 Homepage: http://www.qubes-os.org

--- a/debian/qubes-pdf-converter.install
+++ b/debian/qubes-pdf-converter.install
@@ -6,3 +6,4 @@ usr/lib/qubes/qvm-convert-pdf.gnome
 usr/share/nautilus-python/extensions
 usr/share/nautilus-python/extensions/qvm_convert_pdf_nautilus.py
 usr/share/kde4/services/qvm-convert-pdf.desktop
+usr/share/man/man1/qvm-convert-pdf.1.gz

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,0 +1,23 @@
+PANDOC=pandoc -s -f rst -t man
+
+DOCS=$(patsubst %.rst,%.1.gz,$(wildcard *.rst))
+
+help:
+	@echo "make rst=example.rst preview	-- generate manpage preview from example.rst"
+	@echo "make manpages			-- generate manpages"
+	@echo "make install			-- generate manpages and copy them to /usr/share/man"
+
+install: manpages
+	install -d $(DESTDIR)/usr/share/man/man1
+	install -D $(DOCS) $(DESTDIR)/usr/share/man/man1/
+
+%.1: %.rst
+	$(PANDOC) $< > $@
+
+%.1.gz: %.1
+	gzip -f $<
+
+manpages: $(DOCS)
+
+clean:
+	rm -f $(DOCS)

--- a/doc/qvm-convert-pdf.rst
+++ b/doc/qvm-convert-pdf.rst
@@ -1,0 +1,32 @@
+==================
+QVM-CONVERT-PDF(1)
+==================
+
+NAME
+====
+qvm-convert-pdf - converts a potentially untrusted pdf to a safe-to-view pdf
+
+SYNOPSIS
+========
+| qvm-convert-pdf <pdf to convert>
+
+DESCRIPTION
+===========
+
+Qubes PDF converter is a Qubes Application, which utilizes Qubes flexible qrexec
+(inter-VM communication) infrastructure and Disposable VMs to perform conversion
+of potentially untrusted (e.g. maliciously malformed) PDF files into
+safe-to-view PDF files.
+
+This is done by having the Disposable VM perform the complex (and potentially
+buggy) rendering of the PDF in question) and sending the resulting RGB bitmap
+(simple representation) to the client AppVM. The client AppVM can _trivially_
+verify the received data are indeed the simple representation, and then
+construct a new PDF out of the received bitmap. Of course the price we pay for
+this conversion is loosing any structural information and text-based search in
+the converted PDF.
+
+AUTHORS
+=======
+| Joanna Rutkowska <joanna at invisiblethingslab dot com>
+| Marek Marczykowski <marmarek at invisiblethingslab dot com>

--- a/rpm_spec/qpdf-converter.spec
+++ b/rpm_spec/qpdf-converter.spec
@@ -34,6 +34,8 @@ Vendor:		Invisible Things Lab
 License:	GPL
 URL:		http://www.qubes-os.org
 
+BuildRequires: pandoc 
+
 Requires:	poppler-utils ImageMagick
 Requires:	nautilus-python
 
@@ -63,3 +65,4 @@ rm -rf $RPM_BUILD_ROOT
 %attr(0644,root,root) /etc/qubes-rpc/qubes.PdfConvert
 /usr/share/nautilus-python/extensions/qvm_convert_pdf_nautilus.py*
 /usr/share/kde4/services/qvm-convert-pdf.desktop
+%{_mandir}/man1/qvm-convert-pdf.1*


### PR DESCRIPTION
Added the qvm-convert-pdf manpage. The source file is rst, found in the doc directory. Modifications were made to the root make file to convert the rst to manpages and install them. The relevant files in the rpm_spec and debian configuration were then modified to respect the newly installed files. This PR is part of QubesOS/qubes-issues#2528