### PR TITLE
qvm_convert_pdf_nautilus.py: Execute external commands asynchronously

### DIFF
--- a/qvm_convert_pdf_nautilus.py
+++ b/qvm_convert_pdf_nautilus.py
@@ -1,7 +1,6 @@
 import os
-import subprocess
 
-from gi.repository import Nautilus, GObject
+from gi.repository import Nautilus, GObject, GLib
 
 
 class ConvertPdfItemExtension(GObject.GObject, Nautilus.MenuProvider):
@@ -57,4 +56,6 @@ class ConvertPdfItemExtension(GObject.GObject, Nautilus.MenuProvider):
                 return
 
             gio_file = file_obj.get_location()
-            subprocess.call(['/usr/lib/qubes/qvm-convert-pdf.gnome', gio_file.get_path()])
+            cmd = (['/usr/lib/qubes/qvm-convert-pdf.gnome', gio_file.get_path()])
+            pid = GLib.spawn_async(cmd)[0]
+            GLib.spawn_close_pid(pid)


### PR DESCRIPTION
Using GLib.spawn_async instead of subprocess.call or subprocess.Popen

This prevents Nautilus from getting stuck while executing external commands. And no zombies.

Related: https://github.com/QubesOS/qubes-core-agent-linux/pull/398