### PR TITLE
Add archlinux package build file

### DIFF
--- a/Makefile.builder
+++ b/Makefile.builder
@@ -5,6 +5,7 @@ else ifeq ($(PACKAGE_SET),vm)
   ifeq ($(filter $(DIST), stretch jessie centos7 centos8 centos-stream8 bionic xenial),)
     DEBIAN_BUILD_DIRS := debian
     RPM_SPEC_FILES := rpm_spec/qpdf-converter.spec
+    ARCH_BUILD_DIRS := archlinux
   endif
 endif
 

--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -1,0 +1,27 @@
+pkgname=(qubes-pdf-converter)
+pkgver=$(cat version)
+pkgrel=1
+arch=(x86_64)
+pkgdesc=$(grep "Summary:" ./rpm_spec/qpdf-converter.spec.in | sed 's/Summary://' | xargs)
+url=$(git remote get-url origin)
+license=(GPL)
+makedepends=(git pandoc python-setuptools)
+depends=(
+    graphicsmagick
+    poppler
+    python-nautilus
+    python-click
+    python-pillow
+    python-tqdm
+    python-magic
+    zenity
+)
+
+build() {
+    ln -s "$srcdir"/../ "$srcdir/src"
+}
+
+package() {
+    cd src
+    make install-vm DESTDIR="$pkgdir/"
+}


### PR DESCRIPTION
Based on the open PR #9 I created only the Archlinux package part, because... well... I want to have this packet in Archlinux :upside_down_face: 

Please consider including the package or let me know if anything is blocking. I tested it locally, but without using the Makefile (copying the `PKGBUILD` in the root of the repo and using `makepkg` manually). I do not know if this makes any difference.