### PR TITLE
Configurable qvm-convert-pdf resolution

### DIFF
--- a/doc/qvm-convert-pdf.rst
+++ b/doc/qvm-convert-pdf.rst
@@ -8,7 +8,31 @@ qvm-convert-pdf - converts potentially untrusted PDFs to a safe-to-view PDF
 
 SYNOPSIS
 ========
-| qvm-convert-pdf <PDF to convert ...>
+:command: `qvm-convert-pdf` [-h] [--batch SIZE] [--archive PATH] [--in-place]
+                            [--resolution RESOLUTION]
+
+OPTIONS
+=======
+
+.. option:: --help, -h
+
+   Show help message and exit
+
+.. option:: --batch=SIZE, -b SIZE
+
+   Maximum number of conversion tasks [x>=1]
+
+.. option:: --archive=PATH, -a PATH
+
+   Directory for storing archived files
+
+.. option:: --in-place, -i
+
+   Replace original files instead of archiving them
+
+.. option:: --resolution=RESOLUTION, -r RESOLUTION
+
+   Output resolution. default is 300 ppi [75<=x<=4800]
 
 DESCRIPTION
 ===========

--- a/qubespdfconverter/server.py
+++ b/qubespdfconverter/server.py
@@ -20,6 +20,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
+import argparse
 import asyncio
 import subprocess
 import sys
@@ -30,6 +31,8 @@ from tempfile import TemporaryDirectory
 
 DEPTH = 8
 STDIN_READ_SIZE = 65536
+# Default resolution in ppi (pixel per inch)
+RESOLUTION = 300
 
 
 def unlink(path):
@@ -145,6 +148,8 @@ class Representation:
             "pdftocairo",
             str(self.path),
             "-png",
+            "-r",
+            args.resolution,
             "-f",
             str(self.page),
             "-l",
@@ -270,6 +275,16 @@ class BaseFile:
 
             self.batch.task_done()
 
+parser = argparse.ArgumentParser(
+        prog="qubes.PdfConvert",
+        description="Server side of qvm-convert-pdf",
+        epilog="Refer to qvm-convert-pdf(1) manual for more information")
+
+parser.add_argument('resolution', nargs='?',
+                    default=str(RESOLUTION),
+                    help='Default resolution is 300 ppi')
+
+args = parser.parse_args()
 
 def main():
     try:


### PR DESCRIPTION
 fixes: https://github.com/QubesOS/qubes-issues/issues/2812

The previous default 150ppi resolution was too low.
New default is 300ppi and cofigurable via --resolution option