### PR TITLE
chore: relax nautilus dependency

### DIFF
--- a/archlinux/PKGBUILD.in
+++ b/archlinux/PKGBUILD.in
@@ -9,12 +9,14 @@ makedepends=(git pandoc python-setuptools)
 depends=(
     graphicsmagick
     poppler
-    python-nautilus
     python-click
     python-pillow
     python-tqdm
     python-magic
     zenity
+)
+optdepends=(
+    python-nautilus
 )
 _pkgnvr="${pkgname}-${pkgver}-${pkgrel}"
 source=("${_pkgnvr}.tar.gz")

--- a/debian/control
+++ b/debian/control
@@ -19,9 +19,10 @@ Depends:
  poppler-utils,
  graphicsmagick,
  python3 (>= 3.7.0),
- python3-nautilus | python-nautilus,
  python3-click,
  python3-pillow,
  python3-tqdm,
  ${misc:Depends}
+Suggests:
+ python3-nautilus | python-nautilus,
 Description: The Qubes service for converting untrusted PDF files into trusted ones

--- a/rpm_spec/qpdf-converter.spec.in
+++ b/rpm_spec/qpdf-converter.spec.in
@@ -35,7 +35,7 @@ URL:		http://www.qubes-os.org
 
 BuildArch: noarch
 BuildRequires: make
-BuildRequires: pandoc 
+BuildRequires: pandoc
 BuildRequires: python%{python3_pkgversion}-setuptools
 BuildRequires: python%{python3_pkgversion}-devel
 %if 0%{?is_opensuse}
@@ -46,9 +46,9 @@ BuildRequires: qubes-core-qrexec
 
 Requires:	poppler-utils GraphicsMagick
 %if 0%{?is_opensuse}
-Requires:	python-nautilus-common-files
+Recommends:	(python-nautilus-common-files if nautilus)
 %else
-Requires:	nautilus-python
+Recommends:	(nautilus-python if nautilus)
 %endif
 Requires:	python%{python3_pkgversion} >= 3.7
 Requires:	python%{python3_pkgversion}-pillow


### PR DESCRIPTION
The desktop integration is marked as a strict dependency. This makes it optional (conditionally installed by default on Fedora if nautilus is already installed).

---

[`qvm_convert_pdf_nautilus.py](https://github.com/QubesOS/qubes-app-linux-pdf-converter/blob/main/qvm_convert_pdf_nautilus.py) will still be installed but it appears that this is in line with how qubes packages (including this one) already handle DE-optional files.