### PR TITLE
Initialize asyncio event loop before using it

### DIFF
--- a/qubespdfconverter/client.py
+++ b/qubespdfconverter/client.py
@@ -677,8 +677,7 @@ def main(**params):
     logging.basicConfig(format="error: %(message)s")
 
     if params["files"]:
-        loop = asyncio.get_event_loop()
-        sys.exit(loop.run_until_complete(run(params)))
+        sys.exit(asyncio.run(run(params)))
     else:
         print("No files to sanitize.")
 

--- a/qubespdfconverter/server.py
+++ b/qubespdfconverter/server.py
@@ -297,9 +297,8 @@ def main():
         pdf_path.write_bytes(data)
         base = BaseFile(pdf_path)
 
-        loop = asyncio.get_event_loop()
         try:
-            loop.run_until_complete(base.sanitize())
+            asyncio.run(base.sanitize())
         except subprocess.CalledProcessError:
             sys.exit(1)
 


### PR DESCRIPTION
Python 3.14 (in Fedora 43) throws RunetimeError if event loop is not initialized before using it.

Resolves: QubesOS/qubes-issues#10188