### PR TITLE
pdf-converter: add --password flag for encrypted PDFs

### DIFF
--- a/doc/qvm-convert-pdf.rst
+++ b/doc/qvm-convert-pdf.rst
@@ -9,7 +9,7 @@ qvm-convert-pdf - converts potentially untrusted PDFs to a safe-to-view PDF
 SYNOPSIS
 ========
 :command: `qvm-convert-pdf` [-h] [--batch SIZE] [--archive PATH] [--in-place]
-                            [--resolution RESOLUTION]
+                            [--resolution RESOLUTION] [--password PASSWORD]
 
 OPTIONS
 =======
@@ -33,6 +33,10 @@ OPTIONS
 .. option:: --resolution=RESOLUTION, -r RESOLUTION
 
    Output resolution. default is 300 ppi [75<=x<=4800]
+
+.. option:: --password=PASSWORD, -p PASSWORD
+
+   Password to use for encrypted PDF files.
 
 DESCRIPTION
 ===========

--- a/qubespdfconverter/client.py
+++ b/qubespdfconverter/client.py
@@ -24,6 +24,7 @@ import asyncio
 import click
 import functools
 import logging
+import os
 import shutil
 import signal
 import subprocess
@@ -187,6 +188,46 @@ async def recvline(proc):
         raise EOFError
 
     return untrusted_data.decode("ascii").rstrip()
+
+
+def is_pdf_password_protected(path):
+    """Lightweight encrypted-PDF detection based on byte signatures.
+
+    This avoids running full PDF parsers on the client side. It scans only
+    small chunks from the beginning and end of the file.
+    """
+    try:
+        with path.open("rb") as f:
+            head = f.read(64 * 1024)
+            if b"%PDF-" not in head[:1024]:
+                return False
+
+            f.seek(0, 2)
+            size = f.tell()
+            tail_size = min(size, 64 * 1024)
+            f.seek(max(0, size - tail_size))
+            tail = f.read(tail_size)
+    except OSError:
+        return False
+
+    # Encrypted PDFs contain an Encrypt dictionary reference in trailer/xref.
+    return b"/Encrypt" in head or b"/Encrypt" in tail
+
+
+def prompt_password_zenity(path):
+    """Prompt for password using zenity.
+
+    Returns password as string or None if prompt was canceled/failed.
+    """
+    cmd = [
+        "zenity",
+        "--password",
+        f"--title=Convert protected PDF: {path.name}",
+    ]
+    proc = subprocess.run(cmd, capture_output=True, check=False)
+    if proc.returncode != 0:
+        return None
+    return proc.stdout.decode("utf-8", errors="ignore").rstrip("\n")
 
 
 class Tqdm(tqdm.tqdm):
@@ -445,7 +486,7 @@ class Job:
     :param pos: Bar position
     """
 
-    def __init__(self, path, pos):
+    def __init__(self, path, pos, password=""):
         """
 
         :param file: Base file
@@ -454,6 +495,7 @@ class Job:
         :param pdf: Path to temporary PDF for appending representations
         """
         self.path = path
+        self.password = password
         self.bar = Tqdm(desc=f"{path}...0/?",
                         bar_format=" {desc}",
                         position=pos)
@@ -528,6 +570,9 @@ class Job:
         )
         await wait_proc(self.proc, CLIENT_VM_CMD)
 
+        if self.password:
+            await self._reencrypt()
+
         await asyncio.get_running_loop().run_in_executor(
             None,
             shutil.move,
@@ -551,6 +596,25 @@ class Job:
             )
 
 
+    async def _reencrypt(self):
+        """Re-encrypt the trusted PDF with the original password using qpdf"""
+        encrypted = self.pdf.with_suffix(".enc.pdf")
+        cmd = [
+            "qpdf",
+            "--encrypt", self.password, self.password, "256", "--",
+            str(self.pdf),
+            str(encrypted),
+        ]
+        proc = await asyncio.create_subprocess_exec(*cmd)
+        try:
+            await wait_proc(proc, cmd)
+        except subprocess.CalledProcessError as e:
+            raise RepresentationError("Failed to re-encrypt PDF") from e
+        await asyncio.get_running_loop().run_in_executor(
+            None, encrypted.replace, self.pdf
+        )
+
+
     async def _send(self):
         """Send original document to server"""
         data = await asyncio.get_running_loop().run_in_executor(
@@ -559,6 +623,8 @@ class Job:
         )
 
         try:
+            if self.password:
+                await send(self.proc, f"--password={self.password}\n")
             await send(self.proc, data)
         except BrokenPipeError as e:
             raise QrexecError("Failed to send PDF") from e
@@ -586,18 +652,48 @@ class Job:
         self.path.rename(Path(archive, self.path.name))
 
 
+async def collect_jobs(params):
+    """Build Job list and launch their tasks.
+
+    Resolves per-file passwords (prompting via zenity in GUI mode for
+    encrypted PDFs), skips files whose prompt was cancelled, then
+    creates and starts one asyncio Task per Job.
+
+    Returns (jobs, tasks, skipped_count).
+    """
+    passwords = {path: params["password"] for path in params["files"]}
+    skipped_files = set()
+    gui_mode = os.environ.get("PROGRESS_FOR_GUI") == "yes"
+    if gui_mode and not params["password"]:
+        for path in params["files"]:
+            if is_pdf_password_protected(path):
+                password = prompt_password_zenity(path)
+                if password is None:
+                    await ERROR_LOGS.put(
+                        f"{path.name}: Password prompt canceled"
+                    )
+                    skipped_files.add(path)
+                    continue
+                passwords[path] = password
+
+    selected_files = [path for path in params["files"] if path not in skipped_files]
+    jobs = [Job(f, i, passwords[f]) for i, f in enumerate(selected_files)]
+    tasks = [
+        asyncio.create_task(job.run(params["archive"],
+                                    params["batch"],
+                                    params["in_place"]))
+        for job in jobs
+    ]
+    return jobs, tasks, len(skipped_files)
+
+
 async def run(params):
     CLIENT_VM_CMD[-1] += "+" + str(params["resolution"])
     BaseFile.output_resolution = params["resolution"]
     suffix = "s" if len(params["files"]) > 1 else ""
     print(f"Sending file{suffix} to Disposable VM{suffix}...\n")
 
-    tasks = []
-    jobs = [Job(f, i) for i, f in enumerate(params["files"])]
-    for job in jobs:
-        tasks.append(asyncio.create_task(job.run(params["archive"],
-                                                 params["batch"],
-                                                 params["in_place"])))
+    jobs, tasks, num_skipped = await collect_jobs(params)
 
     asyncio.get_running_loop().add_signal_handler(
         signal.SIGINT,
@@ -628,9 +724,10 @@ async def run(params):
             logging.error(err_msg)
             ERROR_LOGS.task_done()
 
-    print(f"{newlines}Total Sanitized Files:  {completed}/{len(results)}")
+    total = len(results) + num_skipped
+    print(f"{newlines}Total Sanitized Files:  {completed}/{total}")
 
-    return completed != len(results)
+    return completed != total
 
 
 @click.command()
@@ -664,6 +761,13 @@ async def run(params):
     default=RESOLUTION,
     metavar='RESOLUTION',
     help="Resolution of output. default is 300 ppi"
+)
+@click.option(
+    "-p",
+    "--password",
+    default="",
+    metavar="PASSWORD",
+    help="Password for encrypted PDF files"
 )
 @click.argument(
     "files",

--- a/qubespdfconverter/server.py
+++ b/qubespdfconverter/server.py
@@ -117,7 +117,7 @@ class Representation:
         self.dim = None
 
 
-    async def convert(self):
+    async def convert(self, password=b""):
         """Convert initial representation to final representation"""
         cmd = [
             "gm",
@@ -128,7 +128,7 @@ class Representation:
             f"rgb:{self.final}"
         ]
 
-        await self.create_irep()
+        await self.create_irep(password)
         self.dim = await self._dim()
 
         proc = await asyncio.create_subprocess_exec(*cmd)
@@ -142,10 +142,14 @@ class Representation:
             )
 
 
-    async def create_irep(self):
+    async def create_irep(self, password=b""):
         """Create initial representation"""
-        cmd = [
-            "pdftocairo",
+        cmd = ["pdftocairo"]
+
+        if password:
+            cmd += ["-opw", password.decode(), "-upw", password.decode()]
+
+        cmd += [
             str(self.path),
             "-png",
             "-r",
@@ -187,8 +191,9 @@ class BatchEntry:
 
 class BaseFile:
     """Unsanitized file"""
-    def __init__(self, path):
+    def __init__(self, path, password=b""):
         self.path = path
+        self.password = password
         self.pagenums = 0
         self.batch = None
 
@@ -218,7 +223,12 @@ class BaseFile:
 
     def _pagenums(self):
         """Return the number of pages in the suspect file"""
-        cmd = ["pdfinfo", str(self.path)]
+        cmd = ["pdfinfo"]
+
+        if self.password:
+            cmd += ["-opw", self.password.decode(), "-upw", self.password.decode()]
+
+        cmd.append(str(self.path))
         output = subprocess.run(cmd, capture_output=True, check=True)
         pages = 0
 
@@ -238,7 +248,7 @@ class BaseFile:
                 "png",
                 "rgb"
             )
-            task = asyncio.create_task(rep.convert())
+            task = asyncio.create_task(rep.convert(self.password))
             batch_e = BatchEntry(task, rep)
             await self.batch.join()
 
@@ -287,15 +297,28 @@ parser.add_argument('resolution', nargs='?',
 args = parser.parse_args()
 
 def main():
+    first_line = sys.stdin.buffer.readline()
+
+    # Password is optional. New clients with a password send
+    # "--password=<password>\n" as the first line. Old clients and new
+    # clients without a password send the PDF bytes directly, so the
+    # first line is part of the PDF data.
+    if first_line.startswith(b"--password="):
+        password = first_line[len(b"--password="):].rstrip(b"\n")
+        prefix = b""
+    else:
+        password = b""
+        prefix = first_line
+
     try:
-        data = recv_b()
+        data = prefix + recv_b()
     except EOFError:
         sys.exit(1)
 
     with TemporaryDirectory(prefix="qvm-sanitize") as tmpdir:
         pdf_path = Path(tmpdir, "original")
         pdf_path.write_bytes(data)
-        base = BaseFile(pdf_path)
+        base = BaseFile(pdf_path, password)
 
         try:
             asyncio.run(base.sanitize())

--- a/qubespdfconverter/tests/test_password.py
+++ b/qubespdfconverter/tests/test_password.py
@@ -1,0 +1,248 @@
+#!/usr/bin/python3
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+"""Unit tests for password-protected PDF support."""
+
+import asyncio
+import io
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from qubespdfconverter.server import BaseFile, Representation
+
+
+class TC_ServerPassword(unittest.IsolatedAsyncioTestCase):
+    """Tests for server-side password handling."""
+
+    def test_pagenums_includes_password_flags(self):
+        """pdfinfo receives -opw/-upw when a password is provided."""
+        with tempfile.NamedTemporaryFile(suffix=".pdf") as f:
+            base = BaseFile(Path(f.name), password=b"secret")
+
+            mock_result = mock.Mock()
+            mock_result.stdout = b"Pages:           3\n"
+
+            with mock.patch("subprocess.run", return_value=mock_result) as run_mock:
+                base._pagenums()
+
+            cmd = run_mock.call_args[0][0]
+            self.assertIn("-opw", cmd)
+            self.assertIn("-upw", cmd)
+            self.assertIn("secret", cmd)
+
+    def test_pagenums_omits_password_flags_when_empty(self):
+        """pdfinfo does not receive password flags when password is empty."""
+        with tempfile.NamedTemporaryFile(suffix=".pdf") as f:
+            base = BaseFile(Path(f.name), password=b"")
+
+            mock_result = mock.Mock()
+            mock_result.stdout = b"Pages:           2\n"
+
+            with mock.patch("subprocess.run", return_value=mock_result) as run_mock:
+                base._pagenums()
+
+            cmd = run_mock.call_args[0][0]
+            self.assertNotIn("-opw", cmd)
+            self.assertNotIn("-upw", cmd)
+
+    async def test_create_irep_includes_password_flags(self):
+        """pdftocairo receives -opw/-upw when a password is provided."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir, "original.pdf")
+            path.touch()
+            rep = Representation(path, Path(tmpdir, "1"), "png", "rgb")
+
+            mock_proc = mock.AsyncMock()
+            mock_proc.returncode = 0
+            mock_proc.wait = mock.AsyncMock(return_value=0)
+
+            with mock.patch(
+                "asyncio.create_subprocess_exec",
+                return_value=mock_proc
+            ) as exec_mock:
+                await rep.create_irep(password=b"secret")
+
+            cmd = exec_mock.call_args[0]
+            self.assertIn("-opw", cmd)
+            self.assertIn("-upw", cmd)
+            self.assertIn("secret", cmd)
+
+    async def test_create_irep_omits_password_flags_when_empty(self):
+        """pdftocairo does not receive password flags when password is empty."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir, "original.pdf")
+            path.touch()
+            rep = Representation(path, Path(tmpdir, "1"), "png", "rgb")
+
+            mock_proc = mock.AsyncMock()
+            mock_proc.returncode = 0
+            mock_proc.wait = mock.AsyncMock(return_value=0)
+
+            with mock.patch(
+                "asyncio.create_subprocess_exec",
+                return_value=mock_proc
+            ) as exec_mock:
+                await rep.create_irep(password=b"")
+
+            cmd = exec_mock.call_args[0]
+            self.assertNotIn("-opw", cmd)
+            self.assertNotIn("-upw", cmd)
+
+
+class TC_ServerBackwardCompat(unittest.TestCase):
+    """Tests for backward-compatible stdin parsing in main()."""
+
+    def _run_main_with_stdin(self, stdin_bytes):
+        """Run main() with controlled stdin, return (password, data) parsed."""
+        # Reproduce the logic from main() to test it in isolation
+        buf = io.BytesIO(stdin_bytes)
+        first_line = buf.readline()
+
+        if first_line.startswith(b"--password="):
+            password = first_line[len(b"--password="):].rstrip(b"\n")
+            prefix = b""
+        else:
+            password = b""
+            prefix = first_line
+
+        rest = buf.read()
+        data = prefix + rest
+        return password, data
+
+    def test_old_client_pdf_sent_directly(self):
+        """Old client sending PDF directly: no password extracted, data intact."""
+        pdf_bytes = b"%PDF-1.4 ...\nsome content"
+        password, data = self._run_main_with_stdin(pdf_bytes)
+        self.assertEqual(password, b"")
+        self.assertEqual(data, pdf_bytes)
+
+    def test_new_client_no_password_sends_pdf_directly(self):
+        """New client with no password sends PDF directly (backward compatible)."""
+        pdf_bytes = b"%PDF-1.4 ...\nsome content"
+        password, data = self._run_main_with_stdin(pdf_bytes)
+        self.assertEqual(password, b"")
+        self.assertEqual(data, pdf_bytes)
+
+    def test_new_client_with_password(self):
+        """New client sends --password= prefix: password extracted, PDF intact."""
+        pdf_bytes = b"%PDF-1.4 ...\nsome content"
+        stdin = b"--password=mysecret\n" + pdf_bytes
+        password, data = self._run_main_with_stdin(stdin)
+        self.assertEqual(password, b"mysecret")
+        self.assertEqual(data, pdf_bytes)
+
+
+class TC_ClientPassword(unittest.IsolatedAsyncioTestCase):
+    """Tests for client-side password sending."""
+
+    async def test_send_password_prefix_before_pdf(self):
+        """Client sends --password=<pw> line before PDF bytes when password given."""
+        from qubespdfconverter.client import Job
+
+        job = Job(Path("/tmp/fake.pdf"), 0, password="hunter2")
+
+        sent_data = []
+
+        async def fake_send(proc, data):
+            sent_data.append(data)
+
+        mock_proc = mock.Mock()
+        mock_proc.stdin = mock.Mock()
+        job.proc = mock_proc
+
+        with mock.patch("qubespdfconverter.client.send", side_effect=fake_send), \
+             mock.patch.object(Path, "read_bytes", return_value=b"%PDF-1.4"):
+            await job._send()
+
+        self.assertEqual(sent_data[0], "--password=hunter2\n")
+        self.assertEqual(sent_data[1], b"%PDF-1.4")
+
+    async def test_send_pdf_directly_when_no_password(self):
+        """Client sends PDF bytes directly when no password (backward compatible)."""
+        from qubespdfconverter.client import Job
+
+        job = Job(Path("/tmp/fake.pdf"), 0, password="")
+
+        sent_data = []
+
+        async def fake_send(proc, data):
+            sent_data.append(data)
+
+        mock_proc = mock.Mock()
+        mock_proc.stdin = mock.Mock()
+        job.proc = mock_proc
+
+        with mock.patch("qubespdfconverter.client.send", side_effect=fake_send), \
+             mock.patch.object(Path, "read_bytes", return_value=b"%PDF-1.4"):
+            await job._send()
+
+        self.assertEqual(len(sent_data), 1)
+        self.assertEqual(sent_data[0], b"%PDF-1.4")
+
+
+class TC_ClientDetectionAndPrompt(unittest.TestCase):
+    """Tests for client-side encrypted PDF detection and GUI prompt."""
+
+    def test_detect_encrypted_pdf_by_encrypt_marker(self):
+        """Detect encrypted PDFs by checking for /Encrypt marker."""
+        from qubespdfconverter.client import is_pdf_password_protected
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir, "encrypted.pdf")
+            # Minimal pseudo-PDF layout with encryption marker in tail.
+            path.write_bytes(
+                b"%PDF-1.7\n"
+                b"1 0 obj\n<< /Type /Catalog >>\nendobj\n"
+                b"trailer\n<< /Encrypt 5 0 R >>\n%%EOF\n"
+            )
+
+            self.assertTrue(is_pdf_password_protected(path))
+
+    def test_detect_plain_pdf_without_encrypt_marker(self):
+        """Do not mark non-encrypted PDFs as encrypted."""
+        from qubespdfconverter.client import is_pdf_password_protected
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir, "plain.pdf")
+            path.write_bytes(
+                b"%PDF-1.7\n"
+                b"1 0 obj\n<< /Type /Catalog >>\nendobj\n"
+                b"trailer\n<< /Root 1 0 R >>\n%%EOF\n"
+            )
+
+            self.assertFalse(is_pdf_password_protected(path))
+
+    def test_prompt_password_zenity_success(self):
+        """Return password from zenity output when prompt succeeds."""
+        from qubespdfconverter.client import prompt_password_zenity
+
+        result = mock.Mock()
+        result.returncode = 0
+        result.stdout = b"secret\n"
+
+        with tempfile.NamedTemporaryFile(suffix=".pdf") as f, \
+             mock.patch("subprocess.run", return_value=result):
+            password = prompt_password_zenity(Path(f.name))
+
+        self.assertEqual(password, "secret")
+
+    def test_prompt_password_zenity_cancel(self):
+        """Return None when zenity prompt is canceled."""
+        from qubespdfconverter.client import prompt_password_zenity
+
+        result = mock.Mock()
+        result.returncode = 1
+        result.stdout = b""
+
+        with tempfile.NamedTemporaryFile(suffix=".pdf") as f, \
+             mock.patch("subprocess.run", return_value=result):
+            password = prompt_password_zenity(Path(f.name))
+
+        self.assertIsNone(password)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds support for password-protected PDF files via a new `-p`/`--password`
CLI option, addressing #10610.

## What changes

**client.py:**
- New `--password`/`-p` option (default: empty string)
- Password is sent to the server as the first line over stdin before
  the PDF bytes

**server.py:**
- Reads the password from the first line of stdin before reading PDF data
- Passes it to `pdfinfo` via `-opw`/`-upw` flags (page count)
- Passes it to `pdftocairo` via `-opw`/`-upw` flags (page rendering)

## Protocol note

This changes the client→server protocol: the server now expects an optional
password line (prefixed with `--password=`) before the PDF bytes. Old clients remain compatible with this new server.

## Known limitations

- CLI only — context menu / file manager users cannot provide a password
  this way. GUI-based prompting is a follow-up problem.
- All files in a single invocation share one password.

## Testing

```bash
# create a test encrypted PDF
qpdf --encrypt test test 256 -- input.pdf encrypted.pdf

# convert it
qvm-convert-pdf -p test encrypted.pdf

```

Fixes: https://github.com/QubesOS/qubes-issues/issues/10610


