### PR TITLE
pdf-converter: support multiple files and directory input

### DIFF
--- a/qubespdfconverter/client.py
+++ b/qubespdfconverter/client.py
@@ -122,23 +122,54 @@ def modify_click_errors(func):
     return func
 
 
+def expand_dir(path):
+    """Expand a directory to a sorted list of non-symlink .pdf files (non-recursive)"""
+    try:
+        entries = sorted(path.iterdir())
+    except PermissionError as e:
+        raise BadPath(path, "Not readable") from e
+
+    pdfs = []
+    for entry in entries:
+        if entry.is_symlink():
+            continue
+        if entry.is_file() and entry.suffix.lower() == ".pdf":
+            pdfs.append(entry)
+    return pdfs
+
+
 def validate_paths(ctx, param, untrusted_paths):
     """Callback for validating file paths parsed by Click"""
+    paths = []
+
     for untrusted_path in untrusted_paths:
-        if not untrusted_path.resolve().exists():
+        untrusted_resolved = untrusted_path.resolve()
+
+        if not untrusted_resolved.exists():
             raise BadPath(untrusted_path, "No such file or directory")
 
-        if not untrusted_path.resolve().is_file():
+        if untrusted_resolved.is_dir():
+            dir_pdfs = expand_dir(untrusted_resolved)
+            if not dir_pdfs:
+                click.echo(f"warning: no PDF files found in {untrusted_path}",
+                           err=True)
+                continue
+            paths.extend(dir_pdfs)
+            continue
+
+        if not untrusted_resolved.is_file():
             raise BadPath(untrusted_path, "Not a regular file")
 
         try:
-            with untrusted_path.resolve().open("rb"):
+            with untrusted_resolved.open("rb"):
                 pass
         except PermissionError as e:
             raise BadPath(untrusted_path, "Not readable") from e
 
-    paths = untrusted_paths
-    return paths
+        resolved = untrusted_resolved
+        paths.append(resolved)
+
+    return tuple(paths)
 
 
 async def cancel_task(task):

--- a/qubespdfconverter/tests/test_client.py
+++ b/qubespdfconverter/tests/test_client.py
@@ -1,12 +1,15 @@
 #!/usr/bin/python3
 
 import asyncio
+import os
 import signal
+import sys
+import tempfile
 import unittest
 from pathlib import Path
 from unittest import mock
 
-from qubespdfconverter.client import Job, PageError, run
+from qubespdfconverter.client import BadPath, Job, PageError, expand_dir, run, validate_paths
 
 
 class DummyProc:
@@ -67,6 +70,109 @@ class TC_ClientCancel(unittest.IsolatedAsyncioTestCase):
         self.assertFalse(result)
         handled = {call.args[0] for call in add_handler_mock.mock_calls}
         self.assertEqual(handled, {signal.SIGINT, signal.SIGTERM})
+
+
+class TC_ExpandDir(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.d = Path(self.tmpdir.name)
+
+    def tearDown(self):
+        self.tmpdir.cleanup()
+
+    def _touch(self, name):
+        p = self.d / name
+        p.touch()
+        return p
+
+    def test_000_returns_pdf_files_sorted(self):
+        self._touch("b.pdf")
+        self._touch("a.pdf")
+        result = expand_dir(self.d)
+        self.assertEqual([p.name for p in result], ["a.pdf", "b.pdf"])
+
+    def test_001_ignores_non_pdf_files(self):
+        self._touch("doc.pdf")
+        self._touch("image.png")
+        self._touch("notes.txt")
+        result = expand_dir(self.d)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].name, "doc.pdf")
+
+    @unittest.skipUnless(sys.platform != 'win32', 'symlink creation requires POSIX')
+    def test_002_ignores_symlinks(self):
+        real = self._touch("real.pdf")
+        link = self.d / "link.pdf"
+        link.symlink_to(real)
+        result = expand_dir(self.d)
+        names = [p.name for p in result]
+        self.assertIn("real.pdf", names)
+        self.assertNotIn("link.pdf", names)
+
+    def test_003_empty_directory_returns_empty_list(self):
+        result = expand_dir(self.d)
+        self.assertEqual(result, [])
+
+    def test_004_case_insensitive_pdf_extension(self):
+        self._touch("doc.PDF")
+        self._touch("other.Pdf")
+        result = expand_dir(self.d)
+        self.assertEqual(len(result), 2)
+
+    @unittest.skipUnless(sys.platform != 'win32', 'chmod 000 not enforced on Windows')
+    def test_005_unreadable_directory_raises_badpath(self):
+        self.d.chmod(0o000)
+        try:
+            with self.assertRaises(BadPath):
+                expand_dir(self.d)
+        finally:
+            self.d.chmod(0o755)
+
+
+class TC_ValidatePaths(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.d = Path(self.tmpdir.name)
+
+    def tearDown(self):
+        self.tmpdir.cleanup()
+
+    def _touch(self, name):
+        p = self.d / name
+        p.touch()
+        return p
+
+    def test_000_valid_pdf_file_returned(self):
+        pdf = self._touch("doc.pdf")
+        result = validate_paths(None, None, [pdf])
+        self.assertIn(pdf.resolve(), result)
+
+    def test_001_nonexistent_file_raises_badpath(self):
+        with self.assertRaises(BadPath):
+            validate_paths(None, None, [self.d / "missing.pdf"])
+
+    def test_002_directory_expands_to_pdf_files(self):
+        (self.d / "a.pdf").touch()
+        (self.d / "b.pdf").touch()
+        result = validate_paths(None, None, [self.d])
+        self.assertEqual(len(result), 2)
+
+    def test_003_empty_directory_produces_no_paths(self):
+        result = validate_paths(None, None, [self.d])
+        self.assertEqual(result, ())
+
+    @unittest.skipUnless(hasattr(os, 'mkfifo'), 'mkfifo not available on this platform')
+    def test_004_non_file_non_dir_raises_badpath(self):
+        fifo = self.d / "pipe"
+        os.mkfifo(fifo)
+        with self.assertRaises(BadPath):
+            validate_paths(None, None, [fifo])
+
+    def test_005_multiple_files_all_returned(self):
+        a = self._touch("a.pdf")
+        b = self._touch("b.pdf")
+        result = validate_paths(None, None, [a, b])
+        self.assertEqual(set(result), {a.resolve(), b.resolve()})
 
 
 if __name__ == "__main__":

--- a/qvm-convert-pdf.gnome
+++ b/qvm-convert-pdf.gnome
@@ -22,7 +22,7 @@
 
 set -u
 
-if [ $# -ne 1 ]; then
+if [ $# -lt 1 ]; then
 exit 1
 fi
 

--- a/qvm_convert_pdf_nautilus.py
+++ b/qvm_convert_pdf_nautilus.py
@@ -21,17 +21,15 @@ class ConvertPdfItemExtension(GObject.GObject, Nautilus.MenuProvider):
         if not files:
             return
 
-        # TODO:  Only allow pdf files
         for file_obj in files:
 
-            # Do not attach context menu to a directory
-            if file_obj.is_directory():
-                return
-
-            # Do not attach context menu  to anything other that a file
             # local files only; not remote
             if file_obj.get_uri_scheme() != 'file':
                 return
+
+            # Allow directories (they will be expanded by qvm-convert-pdf)
+            if file_obj.is_directory():
+                continue
 
             # Only attach context menu to pdf files
             filename, ext = os.path.splitext(file_obj.get_name())
@@ -47,15 +45,20 @@ class ConvertPdfItemExtension(GObject.GObject, Nautilus.MenuProvider):
         return menu_item,
 
     def on_menu_item_clicked(self, menu, files):
-        '''Called when user chooses files though Nautilus context menu.
+        '''Called when user chooses files through Nautilus context menu.
+
+        Collects all selected PDF files and directories into a single
+        qvm-convert-pdf.gnome invocation so one progress window is shown.
         '''
+        paths = []
         for file_obj in files:
-
-            # Check if file still exists
             if file_obj.is_gone():
-                return
+                continue
+            paths.append(file_obj.get_location().get_path())
 
-            gio_file = file_obj.get_location()
-            cmd = (['/usr/lib/qubes/qvm-convert-pdf.gnome', gio_file.get_path()])
-            pid = GLib.spawn_async(cmd)[0]
-            GLib.spawn_close_pid(pid)
+        if not paths:
+            return
+
+        cmd = ['/usr/lib/qubes/qvm-convert-pdf.gnome'] + paths
+        pid = GLib.spawn_async(cmd)[0]
+        GLib.spawn_close_pid(pid)


### PR DESCRIPTION
## What changed

- `client.py`: `validate_paths` now accepts directories. Each directory is expanded non-recursively to its direct `.pdf` children, skipping symlinks, in sorted order. If a directory has no PDFs a warning is printed and it is skipped instead of aborting.
- `qvm_convert_pdf_nautilus.py`: nautilus extension now allows directories in the selection and passes all selected paths in a **single** `qvm-convert-pdf.gnome` call (one progress window instead of one per file).
- `qvm-convert-pdf.gnome`: changed `$# -ne 1` to `$# -lt 1` to accept multiple arguments.

## Security note

Each file still gets its own Disposable VM — the safe default. Single-DVM batching (faster but weaker isolation, as noted in the issue) is intentionally out of scope here and would need a separate discussion.

## Testing

```bash
# multiple files
qvm-convert-pdf file1.pdf file2.pdf file3.pdf

# directory
qvm-convert-pdf ~/Downloads/pdfs/

# mixed
qvm-convert-pdf file1.pdf ~/Downloads/pdfs/
```

Fixes: https://github.com/QubesOS/qubes-issues/issues/3966