### PR TITLE
Improve cancel conversion failure message

### DIFF
--- a/qubespdfconverter/tests/__init__.py
+++ b/qubespdfconverter/tests/__init__.py
@@ -153,6 +153,7 @@ class TC_00_PDFConverter(qubes.tests.extra.ExtraTestCase):
         # collection. The timeout must be shorter than the conversion time, to
         # be sure it was canceled.
         timeout = 20
+        orig_timeout = timeout
         while True:
             domains_after = set(self.app.domains)
             if domains_after == domains_before:
@@ -160,9 +161,10 @@ class TC_00_PDFConverter(qubes.tests.extra.ExtraTestCase):
             self.loop.run_until_complete(asyncio.sleep(1))
             timeout -= 1
             if timeout <= 0:
+                rest = [domain.name for domain in domains_after - domains_before]
                 self.fail(
-                    'DispVM not cleaned up 10s after cancel: {}'.format(
-                        domains_after - domains_before))
+                    'DispVM not cleaned up {}s after cancel: {}'.format(
+                        orig_timeout, rest))
 
 
 def list_tests():


### PR DESCRIPTION
I didn't notice that the failure message hardcoded the time last time I changed the timeout.

It's failing on [openqa](https://openqa.qubes-os.org/tests/175094#step/TC_00_PDFConverter_fedora-43-xfce/5). Investigation says that it is using latest version `fedora-43-xfce: qubes-pdf-converter-2.1.26-1.4.fc43.noarch`. Might need to increase timeout to 30.

---

scheduled for openqa: https://github.com/QubesOS/qubes-core-admin/pull/783#issuecomment-4336876981