### PR TITLE
pdf-converter: add renderer dispatch

### DIFF
--- a/qubespdfconverter/server.py
+++ b/qubespdfconverter/server.py
@@ -146,6 +146,21 @@ class PdfRenderer:
         return rep
 
 
+RENDERERS = {
+    "pdf": PdfRenderer,
+}
+
+
+def create_renderer(name, path, password=b"", resolution=RESOLUTION):
+    """Create a renderer for the requested converter type."""
+    try:
+        renderer_cls = RENDERERS[name]
+    except KeyError as exc:
+        raise ValueError(f"Unsupported renderer: {name}") from exc
+
+    return renderer_cls(path, password, resolution)
+
+
 class Representation:
     """Umbrella object for a file's initial and final representations
 
@@ -220,10 +235,9 @@ class BatchEntry:
 
 class BaseFile:
     """Unsanitized file"""
-    def __init__(self, path, password=b""):
+    def __init__(self, path, renderer):
         self.path = path
-        self.password = password
-        self.renderer = PdfRenderer(path, password, args.resolution)
+        self.renderer = renderer
         self.pagenums = 0
         self.batch = None
 
@@ -333,7 +347,8 @@ def main():
     with TemporaryDirectory(prefix="qvm-sanitize") as tmpdir:
         pdf_path = Path(tmpdir, "original")
         pdf_path.write_bytes(data)
-        base = BaseFile(pdf_path, password)
+        renderer = create_renderer("pdf", pdf_path, password, args.resolution)
+        base = BaseFile(pdf_path, renderer)
 
         try:
             asyncio.run(base.sanitize())

--- a/qubespdfconverter/tests/test_password.py
+++ b/qubespdfconverter/tests/test_password.py
@@ -11,7 +11,7 @@ import unittest
 from pathlib import Path
 from unittest import mock
 
-from qubespdfconverter.server import BaseFile, PdfRenderer
+from qubespdfconverter.server import BaseFile, PdfRenderer, create_renderer
 
 
 class TC_ServerPassword(unittest.IsolatedAsyncioTestCase):
@@ -20,7 +20,8 @@ class TC_ServerPassword(unittest.IsolatedAsyncioTestCase):
     def test_pagenums_includes_password_flags(self):
         """pdfinfo receives -opw/-upw when a password is provided."""
         with tempfile.NamedTemporaryFile(suffix=".pdf") as f:
-            base = BaseFile(Path(f.name), password=b"secret")
+            renderer = PdfRenderer(Path(f.name), password=b"secret")
+            base = BaseFile(Path(f.name), renderer)
 
             mock_result = mock.Mock()
             mock_result.stdout = b"Pages:           3\n"
@@ -36,7 +37,8 @@ class TC_ServerPassword(unittest.IsolatedAsyncioTestCase):
     def test_pagenums_omits_password_flags_when_empty(self):
         """pdfinfo does not receive password flags when password is empty."""
         with tempfile.NamedTemporaryFile(suffix=".pdf") as f:
-            base = BaseFile(Path(f.name), password=b"")
+            renderer = PdfRenderer(Path(f.name), password=b"")
+            base = BaseFile(Path(f.name), renderer)
 
             mock_result = mock.Mock()
             mock_result.stdout = b"Pages:           2\n"
@@ -90,6 +92,26 @@ class TC_ServerPassword(unittest.IsolatedAsyncioTestCase):
             cmd = exec_mock.call_args[0]
             self.assertNotIn("-opw", cmd)
             self.assertNotIn("-upw", cmd)
+
+    def test_create_renderer_returns_pdf_renderer(self):
+        """The server dispatch table creates the PDF renderer."""
+        with tempfile.NamedTemporaryFile(suffix=".pdf") as f:
+            renderer = create_renderer(
+                "pdf",
+                Path(f.name),
+                password=b"secret",
+                resolution=200,
+            )
+
+        self.assertIsInstance(renderer, PdfRenderer)
+        self.assertEqual(renderer.password, b"secret")
+        self.assertEqual(renderer.resolution, "200")
+
+    def test_create_renderer_rejects_unknown_type(self):
+        """Unknown renderer names fail before any conversion starts."""
+        with tempfile.NamedTemporaryFile(suffix=".pdf") as f:
+            with self.assertRaises(ValueError):
+                create_renderer("office", Path(f.name))
 
 
 class TC_ServerBackwardCompat(unittest.TestCase):


### PR DESCRIPTION
This is a small structure-only follow-up to #42.

It adds a simple renderer dispatch table on the server side and creates the current PDF renderer through that path. BaseFile now receives the renderer it should use instead of creating PdfRenderer directly.

PDF is still the only registered renderer in this PR. There is no new file type support yet, and no intended change to qvm-convert-pdf, qubes.PdfConvert, or the qrexec protocol.

Tests:
- `python -c "import sys, unittest; sys.argv=['unittest']; suite=unittest.defaultTestLoader.discover('qubespdfconverter/tests', pattern='test*.py'); result=unittest.TextTestRunner(verbosity=2).run(suite); sys.exit(not result.wasSuccessful())"`
- `git diff --cached --check` before commit