### PR TITLE
pdf-converter: add qvm-convert-file PDF dispatch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,7 @@ install-dom0:
 	$(PYTHON) setup.py install -O1 --root $(DESTDIR)
 	# not needed in dom0
 	rm -f $(DESTDIR)/usr/bin/qvm-convert-pdf
+	rm -f $(DESTDIR)/usr/bin/qvm-convert-file
 	rm -f $(DESTDIR)/usr/lib/qubes/qpdf-convert-server
 
 clean:

--- a/debian/control
+++ b/debian/control
@@ -21,6 +21,7 @@ Depends:
  python3 (>= 3.7.0),
  python3-nautilus | python-nautilus,
  python3-click,
+ python3-magic,
  python3-pillow,
  python3-tqdm,
  ${misc:Depends}

--- a/debian/qubes-pdf-converter.install
+++ b/debian/qubes-pdf-converter.install
@@ -1,6 +1,7 @@
 usr/lib/qubes/qpdf-convert-server
 etc/qubes-rpc/qubes.PdfConvert
 usr/bin/qvm-convert-pdf
+usr/bin/qvm-convert-file
 usr/lib/qubes/qvm-convert-pdf.gnome
 usr/share/nautilus-python/extensions
 usr/share/nautilus-python/extensions/qvm_convert_pdf_nautilus.py

--- a/qubespdfconverter/file_client.py
+++ b/qubespdfconverter/file_client.py
@@ -1,0 +1,98 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+
+import asyncio
+import click
+import logging
+import sys
+
+from pathlib import Path
+
+from qubespdfconverter import client as pdf_client
+
+try:
+    import magic
+except ImportError:
+    magic = None
+
+
+MIME_DISPATCH = {
+    "application/pdf": "pdf",
+}
+
+
+def detect_mime(path):
+    if magic is None:
+        raise click.ClickException("python-magic is required for MIME detection")
+    return magic.from_file(str(path), mime=True)
+
+
+def check_supported_files(paths):
+    for path in paths:
+        untrusted_mime = detect_mime(path)
+        if MIME_DISPATCH.get(untrusted_mime) != "pdf":
+            raise click.ClickException(
+                f"{path}: unsupported file type: {untrusted_mime}"
+            )
+
+
+@click.command()
+@click.option(
+    "-b",
+    "--batch",
+    type=click.IntRange(1),
+    default=50,
+    metavar="SIZE",
+    help="Maximum number of conversion tasks"
+)
+@click.option(
+    "-a",
+    "--archive",
+    type=Path,
+    default=Path(Path.home(), "QubesUntrustedPDFs"),
+    metavar="PATH",
+    help="Directory for storing archived files"
+)
+@click.option(
+    "-i",
+    "--in-place",
+    is_flag=True,
+    help="Replace original files instead of archiving them"
+)
+@click.option(
+    "-r",
+    "--resolution",
+    type=click.IntRange(75, 4800),
+    nargs=1,
+    default=pdf_client.RESOLUTION,
+    metavar="RESOLUTION",
+    help="Resolution of output. default is 300 ppi"
+)
+@click.option(
+    "-p",
+    "--password",
+    default="",
+    metavar="PASSWORD",
+    help="Password for encrypted PDF files"
+)
+@click.argument(
+    "files",
+    type=Path,
+    nargs=-1,
+    callback=pdf_client.validate_paths,
+    metavar="[FILES ...]"
+)
+@pdf_client.modify_click_errors
+def main(**params):
+    logging.basicConfig(format="error: %(message)s")
+
+    if not params["files"]:
+        print("No files to sanitize.")
+        return
+
+    check_supported_files(params["files"])
+    sys.exit(asyncio.run(pdf_client.run(params)))
+
+
+if __name__ == "__main__":
+    main()

--- a/qubespdfconverter/file_client.py
+++ b/qubespdfconverter/file_client.py
@@ -1,0 +1,72 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+
+import asyncio
+import click
+import logging
+import sys
+
+from pathlib import Path
+
+from qubespdfconverter import client as pdf_client
+
+
+@click.command()
+@click.option(
+    "-b",
+    "--batch",
+    type=click.IntRange(1),
+    default=50,
+    metavar="SIZE",
+    help="Maximum number of conversion tasks"
+)
+@click.option(
+    "-a",
+    "--archive",
+    type=Path,
+    default=Path(Path.home(), "QubesUntrustedPDFs"),
+    metavar="PATH",
+    help="Directory for storing archived files"
+)
+@click.option(
+    "-i",
+    "--in-place",
+    is_flag=True,
+    help="Replace original files instead of archiving them"
+)
+@click.option(
+    "-r",
+    "--resolution",
+    type=click.IntRange(75, 4800),
+    nargs=1,
+    default=pdf_client.RESOLUTION,
+    metavar="RESOLUTION",
+    help="Resolution of output. default is 300 ppi"
+)
+@click.option(
+    "-p",
+    "--password",
+    default="",
+    metavar="PASSWORD",
+    help="Password for encrypted PDF files"
+)
+@click.argument(
+    "files",
+    type=Path,
+    nargs=-1,
+    callback=pdf_client.validate_paths,
+    metavar="[FILES ...]"
+)
+@pdf_client.modify_click_errors
+def main(**params):
+    logging.basicConfig(format="error: %(message)s")
+
+    if not params["files"]:
+        print("No files to sanitize.")
+        return
+
+    sys.exit(asyncio.run(pdf_client.run(params)))
+
+
+if __name__ == "__main__":
+    main()

--- a/qubespdfconverter/server.py
+++ b/qubespdfconverter/server.py
@@ -29,6 +29,11 @@ from dataclasses import dataclass
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
+try:
+    import magic
+except ImportError:
+    magic = None
+
 DEPTH = 8
 STDIN_READ_SIZE = 65536
 # Default resolution in ppi (pixel per inch)
@@ -149,6 +154,27 @@ class PdfRenderer:
 RENDERERS = {
     "pdf": PdfRenderer,
 }
+
+MIME_DISPATCH = {
+    "application/pdf": "pdf",
+}
+
+
+def detect_mime(path):
+    """Detect file type inside the DisposableVM side."""
+    if magic is None:
+        raise ValueError("python-magic is required for MIME detection")
+
+    return magic.from_file(str(path), mime=True)
+
+
+def renderer_name_for_path(path):
+    """Return renderer name for a file detected on the server side."""
+    mime_type = detect_mime(path)
+    try:
+        return MIME_DISPATCH[mime_type]
+    except KeyError as exc:
+        raise ValueError(f"Unsupported file type: {mime_type}") from exc
 
 
 def create_renderer(name, path, password=b"", resolution=RESOLUTION):
@@ -347,12 +373,20 @@ def main():
     with TemporaryDirectory(prefix="qvm-sanitize") as tmpdir:
         pdf_path = Path(tmpdir, "original")
         pdf_path.write_bytes(data)
-        renderer = create_renderer("pdf", pdf_path, password, args.resolution)
-        base = BaseFile(pdf_path, renderer)
 
         try:
+            renderer = create_renderer(
+                renderer_name_for_path(pdf_path),
+                pdf_path,
+                password,
+                args.resolution,
+            )
+            base = BaseFile(pdf_path, renderer)
             asyncio.run(base.sanitize())
         except subprocess.CalledProcessError:
+            sys.exit(1)
+        except ValueError as exc:
+            print(f"error: {exc}", file=sys.stderr, flush=True)
             sys.exit(1)
 
 

--- a/qubespdfconverter/tests/test_file_client.py
+++ b/qubespdfconverter/tests/test_file_client.py
@@ -1,0 +1,63 @@
+#!/usr/bin/python3
+
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from click.testing import CliRunner
+
+from qubespdfconverter import file_client
+
+
+class TC_FileClient(unittest.TestCase):
+    def test_uses_pdf_converter_without_client_mime_check(self):
+        runner = CliRunner()
+
+        with runner.isolated_filesystem():
+            Path("report.pdf").write_bytes(b"%PDF-1.7\n")
+
+            with mock.patch(
+                "qubespdfconverter.file_client.pdf_client.run",
+                new=mock.AsyncMock(return_value=False),
+            ) as run_mock:
+                result = runner.invoke(file_client.main, ["report.pdf"])
+
+        self.assertEqual(result.exit_code, 0)
+        run_mock.assert_awaited_once()
+        params = run_mock.await_args.args[0]
+        self.assertEqual(params["files"], (Path("report.pdf"),))
+
+    def test_extension_is_not_checked_on_client(self):
+        runner = CliRunner()
+
+        with runner.isolated_filesystem():
+            Path("report.docx").write_bytes(b"not a pdf")
+
+            with mock.patch(
+                "qubespdfconverter.file_client.pdf_client.run",
+                new=mock.AsyncMock(return_value=False),
+            ) as run_mock:
+                result = runner.invoke(file_client.main, ["report.docx"])
+
+        self.assertEqual(result.exit_code, 0)
+        run_mock.assert_awaited_once()
+        params = run_mock.await_args.args[0]
+        self.assertEqual(params["files"], (Path("report.docx"),))
+
+    def test_failed_server_conversion_is_reported(self):
+        runner = CliRunner()
+
+        with runner.isolated_filesystem():
+            Path("fake.pdf").write_bytes(b"not a pdf")
+
+            with mock.patch(
+                "qubespdfconverter.file_client.pdf_client.run",
+                new=mock.AsyncMock(return_value=True),
+            ):
+                result = runner.invoke(file_client.main, ["fake.pdf"])
+
+        self.assertNotEqual(result.exit_code, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/qubespdfconverter/tests/test_file_client.py
+++ b/qubespdfconverter/tests/test_file_client.py
@@ -1,0 +1,76 @@
+#!/usr/bin/python3
+
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from click.testing import CliRunner
+
+from qubespdfconverter import file_client
+
+
+class TC_FileClient(unittest.TestCase):
+    def test_pdf_mime_uses_pdf_converter(self):
+        runner = CliRunner()
+
+        with runner.isolated_filesystem():
+            Path("report.pdf").write_bytes(b"%PDF-1.7\n")
+
+            with mock.patch(
+                "qubespdfconverter.file_client.detect_mime",
+                return_value="application/pdf",
+            ), mock.patch(
+                "qubespdfconverter.file_client.pdf_client.run",
+                new=mock.AsyncMock(return_value=False),
+            ) as run_mock:
+                result = runner.invoke(file_client.main, ["report.pdf"])
+
+        self.assertEqual(result.exit_code, 0)
+        run_mock.assert_awaited_once()
+        params = run_mock.await_args.args[0]
+        self.assertEqual(params["files"], (Path("report.pdf"),))
+
+    def test_unsupported_mime_is_rejected(self):
+        runner = CliRunner()
+
+        with runner.isolated_filesystem():
+            Path("report.docx").write_bytes(b"not a pdf")
+
+            with mock.patch(
+                "qubespdfconverter.file_client.detect_mime",
+                return_value=(
+                    "application/vnd.openxmlformats-officedocument."
+                    "wordprocessingml.document"
+                ),
+            ), mock.patch(
+                "qubespdfconverter.file_client.pdf_client.run",
+                new=mock.AsyncMock(),
+            ) as run_mock:
+                result = runner.invoke(file_client.main, ["report.docx"])
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("unsupported file type", result.output)
+        run_mock.assert_not_called()
+
+    def test_extension_does_not_override_mime(self):
+        runner = CliRunner()
+
+        with runner.isolated_filesystem():
+            Path("fake.pdf").write_text("plain text", encoding="utf-8")
+
+            with mock.patch(
+                "qubespdfconverter.file_client.detect_mime",
+                return_value="text/plain",
+            ), mock.patch(
+                "qubespdfconverter.file_client.pdf_client.run",
+                new=mock.AsyncMock(),
+            ) as run_mock:
+                result = runner.invoke(file_client.main, ["fake.pdf"])
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("text/plain", result.output)
+        run_mock.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/qubespdfconverter/tests/test_password.py
+++ b/qubespdfconverter/tests/test_password.py
@@ -11,7 +11,12 @@ import unittest
 from pathlib import Path
 from unittest import mock
 
-from qubespdfconverter.server import BaseFile, PdfRenderer, create_renderer
+from qubespdfconverter.server import (
+    BaseFile,
+    PdfRenderer,
+    create_renderer,
+    renderer_name_for_path,
+)
 
 
 class TC_ServerPassword(unittest.IsolatedAsyncioTestCase):
@@ -112,6 +117,27 @@ class TC_ServerPassword(unittest.IsolatedAsyncioTestCase):
         with tempfile.NamedTemporaryFile(suffix=".pdf") as f:
             with self.assertRaises(ValueError):
                 create_renderer("office", Path(f.name))
+
+    def test_server_dispatches_pdf_mime_to_pdf_renderer_name(self):
+        """MIME-based renderer selection happens on the server side."""
+        with tempfile.NamedTemporaryFile(suffix=".pdf") as f, \
+             mock.patch(
+                 "qubespdfconverter.server.detect_mime",
+                 return_value="application/pdf",
+             ):
+            renderer_name = renderer_name_for_path(Path(f.name))
+
+        self.assertEqual(renderer_name, "pdf")
+
+    def test_server_rejects_unsupported_mime(self):
+        """Unsupported MIME types fail before selecting a renderer."""
+        with tempfile.NamedTemporaryFile(suffix=".txt") as f, \
+             mock.patch(
+                 "qubespdfconverter.server.detect_mime",
+                 return_value="text/plain",
+             ):
+            with self.assertRaises(ValueError):
+                renderer_name_for_path(Path(f.name))
 
 
 class TC_ServerBackwardCompat(unittest.TestCase):

--- a/rpm_spec/qpdf-converter.spec.in
+++ b/rpm_spec/qpdf-converter.spec.in
@@ -53,6 +53,7 @@ Requires:	nautilus-python
 Requires:	python%{python3_pkgversion} >= 3.7
 Requires:	python%{python3_pkgversion}-pillow
 Requires:	python%{python3_pkgversion}-click
+Requires:	python%{python3_pkgversion}-magic
 Requires:	python%{python3_pkgversion}-tqdm
 Recommends:	zenity
 
@@ -82,6 +83,7 @@ rm -rf $RPM_BUILD_ROOT
 /usr/lib/qubes/qpdf-convert-server
 /usr/lib/qubes/qvm-convert-pdf.gnome
 /usr/bin/qvm-convert-pdf
+/usr/bin/qvm-convert-file
 /usr/share/nautilus-python/extensions/qvm_convert_pdf_nautilus.py*
 /usr/share/file-manager/actions/qvm-convert-pdf-pcmanfm-qt.desktop
 %if !0%{?is_opensuse}

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ class CustomInstall(setuptools.command.install.install):
         scripts = [
             ('usr/lib/qubes/qpdf-convert-server', 'qubespdfconverter.server'),
             ('usr/bin/qvm-convert-pdf', 'qubespdfconverter.client'),
+            ('usr/bin/qvm-convert-file', 'qubespdfconverter.file_client'),
         ]
         for file, pkg in scripts:
             path = os.path.join(self.root, file)
@@ -64,6 +65,7 @@ setup(
     install_requires=[
         'Click',
         'Pillow',
+        'python-magic',
         'tqdm'
     ],
     entry_points={


### PR DESCRIPTION
﻿This adds the first version of `qvm-convert-file`.

For now it only accepts PDFs. It checks the detected MIME type with python-magic, routes `application/pdf` through the existing PDF converter path, and rejects other file types with a clear unsupported-type error.

There is no new qrexec service here and no new document conversion yet. `qvm-convert-pdf` keeps the same behavior.

I kept this PDF-only so the command shape can be reviewed before adding document conversion.

Tests:
- `python -c "import sys, unittest; sys.argv=['unittest']; suite=unittest.defaultTestLoader.discover('qubespdfconverter/tests', pattern='test*.py'); result=unittest.TextTestRunner(verbosity=2).run(suite); sys.exit(not result.wasSuccessful())"`
- `python -m pylint --rcfile=.pylintrc qubespdfconverter/file_client.py qubespdfconverter/tests/test_file_client.py`
- `git diff --check`


Fixes https://github.com/QubesOS/qubes-issues/issues/10884.
