### PR TITLE
pdf-converter: add docx conversion through LibreOffice

### DIFF
--- a/qubespdfconverter/server.py
+++ b/qubespdfconverter/server.py
@@ -22,6 +22,7 @@
 
 import argparse
 import asyncio
+import shutil
 import subprocess
 import sys
 
@@ -147,12 +148,56 @@ class PdfRenderer:
         return rep
 
 
+class DocxRenderer:
+    """Convert DOCX documents to PDF, then render the PDF pages."""
+
+    def __init__(self, path, password=b"", resolution=RESOLUTION):
+        self.path = path
+        self.resolution = resolution
+        self._pdf_renderer = None
+
+    def pdf_renderer(self):
+        if self._pdf_renderer is not None:
+            return self._pdf_renderer
+
+        docx_path = Path(self.path.parent, "input.docx")
+        shutil.copyfile(self.path, docx_path)
+
+        cmd = [
+            "libreoffice",
+            "--headless",
+            "--convert-to",
+            "pdf",
+            "--outdir",
+            str(self.path.parent),
+            str(docx_path),
+        ]
+        subprocess.run(cmd, capture_output=True, check=True)
+
+        pdf_path = docx_path.with_suffix(".pdf")
+        if not pdf_path.exists():
+            raise ValueError("DOCX conversion did not produce a PDF")
+
+        self._pdf_renderer = PdfRenderer(pdf_path, resolution=self.resolution)
+        return self._pdf_renderer
+
+    def page_count(self):
+        """Return the number of pages in the converted document."""
+        return self.pdf_renderer().page_count()
+
+    async def render_page(self, page, prefix):
+        """Render one converted document page into an image."""
+        return await self.pdf_renderer().render_page(page, prefix)
+
+
 RENDERERS = {
+    "docx": DocxRenderer,
     "pdf": PdfRenderer,
 }
 
 MIME_DISPATCH = {
     "application/pdf": "pdf",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document": ("docx"),
 }
 
 

--- a/qubespdfconverter/server.py
+++ b/qubespdfconverter/server.py
@@ -103,13 +103,11 @@ class PdfRenderer:
         self.password = password
         self.resolution = str(resolution)
 
-
     def _password_args(self):
         if not self.password:
             return []
         password = self.password.decode()
         return ["-opw", password, "-upw", password]
-
 
     def page_count(self):
         """Return the number of pages in the PDF."""
@@ -122,7 +120,6 @@ class PdfRenderer:
                 pages = int(line.split(":")[1])
 
         return pages
-
 
     async def create_page_image(self, page, output):
         """Render one PDF page into an image."""
@@ -137,12 +134,11 @@ class PdfRenderer:
             "-l",
             str(page),
             "-singlefile",
-            str(Path(output.parent, output.stem))
+            str(Path(output.parent, output.stem)),
         ]
 
         proc = await asyncio.create_subprocess_exec(*cmd)
         await wait_proc(proc, cmd)
-
 
     async def render_page(self, page, prefix):
         """Create an intermediate page representation."""
@@ -211,7 +207,6 @@ class Representation:
         self.final = prefix.with_suffix(f".{f_suffix}")
         self.dim = None
 
-
     async def convert(self):
         """Convert initial representation to final representation"""
         cmd = [
@@ -220,7 +215,7 @@ class Representation:
             str(self.initial),
             "-depth",
             str(DEPTH),
-            f"rgb:{self.final}"
+            f"rgb:{self.final}",
         ]
 
         self.dim = await self._dim()
@@ -229,20 +224,12 @@ class Representation:
         try:
             await wait_proc(proc, cmd)
         finally:
-            await asyncio.get_running_loop().run_in_executor(
-                None,
-                unlink,
-                self.initial
-            )
-
+            await asyncio.get_running_loop().run_in_executor(None, unlink, self.initial)
 
     async def _dim(self):
         """Identify image dimensions of initial representation"""
         cmd = ["gm", "identify", "-format", "%w %h", str(self.initial)]
-        proc = await asyncio.create_subprocess_exec(
-            *cmd,
-            stdout=subprocess.PIPE
-        )
+        proc = await asyncio.create_subprocess_exec(*cmd, stdout=subprocess.PIPE)
 
         try:
             output, _ = await proc.communicate()
@@ -261,12 +248,12 @@ class BatchEntry:
 
 class BaseFile:
     """Unsanitized file"""
+
     def __init__(self, path, renderer):
         self.path = path
         self.renderer = renderer
         self.pagenums = 0
         self.batch = None
-
 
     async def sanitize(self):
         """Start sanitization tasks"""
@@ -290,18 +277,15 @@ class BaseFile:
 
             raise
 
-
     def _pagenums(self):
         """Return the number of pages in the suspect file"""
         return self.renderer.page_count()
-
 
     async def _publish(self):
         """Extract initial representations and enqueue conversion tasks"""
         for page in range(1, self.pagenums + 1):
             rep = await self.renderer.render_page(
-                page,
-                Path(self.path.parent, str(page))
+                page, Path(self.path.parent, str(page))
             )
             task = asyncio.create_task(rep.convert())
             batch_e = BatchEntry(task, rep)
@@ -313,7 +297,6 @@ class BaseFile:
                 await cancel_task(task)
                 raise
 
-
     async def _consume(self):
         """Await conversion tasks and send final representation to client"""
         for _ in range(self.pagenums):
@@ -321,35 +304,36 @@ class BaseFile:
             await batch_e.task
 
             rgb_data = await asyncio.get_running_loop().run_in_executor(
-                None,
-                batch_e.rep.final.read_bytes
+                None, batch_e.rep.final.read_bytes
             )
 
             await asyncio.get_running_loop().run_in_executor(
-                None,
-                unlink,
-                batch_e.rep.final
+                None, unlink, batch_e.rep.final
             )
 
             await asyncio.get_running_loop().run_in_executor(
-                None,
-                send,
-                batch_e.rep.dim
+                None, send, batch_e.rep.dim
             )
             send_b(rgb_data)
 
             self.batch.task_done()
 
-parser = argparse.ArgumentParser(
-        prog="qubes.PdfConvert",
-        description="Server side of qvm-convert-pdf",
-        epilog="Refer to qvm-convert-pdf(1) manual for more information")
 
-parser.add_argument('resolution', nargs='?',
-                    default=str(RESOLUTION),
-                    help='Default resolution is 300 ppi')
+parser = argparse.ArgumentParser(
+    prog="qubes.PdfConvert",
+    description="Server side of qvm-convert-pdf",
+    epilog="Refer to qvm-convert-pdf(1) manual for more information",
+)
+
+parser.add_argument(
+    "resolution",
+    nargs="?",
+    default=str(RESOLUTION),
+    help="Default resolution is 300 ppi",
+)
 
 args = parser.parse_args()
+
 
 def main():
     first_line = sys.stdin.buffer.readline()
@@ -359,7 +343,7 @@ def main():
     # clients without a password send the PDF bytes directly, so the
     # first line is part of the PDF data.
     if first_line.startswith(b"--password="):
-        password = first_line[len(b"--password="):].rstrip(b"\n")
+        password = first_line[len(b"--password=") :].rstrip(b"\n")
         prefix = b""
     else:
         password = b""

--- a/qubespdfconverter/tests/__init__.py
+++ b/qubespdfconverter/tests/__init__.py
@@ -73,6 +73,52 @@ class TC_00_PDFConverter(qubes.tests.extra.ExtraTestCase):
         if p.returncode != 0:
             self.skipTest('failed to create test pdf: {}'.format(stdout))
 
+    def create_docx(self, filename, text):
+        '''Create DOCX file with given (textual) content
+
+        :param filename: output filename
+        :param text: text to be placed in the document
+        '''
+        script = r'''
+import sys
+import zipfile
+
+filename = sys.argv[1]
+text = sys.argv[2]
+
+content_types = ''' + repr("""<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+</Types>
+""") + r'''
+rels = ''' + repr("""<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>
+</Relationships>
+""") + r'''
+document = f''' + repr("""<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:body>
+    <w:p><w:r><w:t>{text}</w:t></w:r></w:p>
+    <w:sectPr/>
+  </w:body>
+</w:document>
+""") + r'''.format(text=text)
+
+with zipfile.ZipFile(filename, "w") as docx:
+    docx.writestr("[Content_Types].xml", content_types)
+    docx.writestr("_rels/.rels", rels)
+    docx.writestr("word/document.xml", document)
+'''
+        p = self.vm.run(
+            'python3 - "{}" "{}"'.format(filename, text),
+            passio_popen=True)
+        (stdout, _) = p.communicate(script.encode())
+        if p.returncode != 0:
+            self.skipTest('failed to create test docx: {}'.format(stdout))
+
     def get_pdfinfo(self, filename):
         p = self.vm.run('pdfinfo "{}"'.format(filename), passio_popen=True)
         (stdout, _) = p.communicate()
@@ -165,6 +211,26 @@ class TC_00_PDFConverter(qubes.tests.extra.ExtraTestCase):
                 self.fail(
                     'DispVM not cleaned up {}s after cancel: {}'.format(
                         orig_timeout, rest))
+
+    def test_005_docx(self):
+        if self.vm.run('command -v libreoffice >/dev/null', wait=True) != 0:
+            self.skipTest('libreoffice not installed')
+        self.create_docx('test.docx', 'This is test')
+        p = self.vm.run(
+            'cp test.docx orig.docx; qvm-convert-file test.docx 2>&1',
+            passio_popen=True)
+        (stdout, _) = p.communicate()
+        self.assertEqual(
+            p.returncode, 0, 'qvm-convert-file failed: {}'.format(stdout))
+        self.assertEqual(
+            self.vm.run('test -r "test.trusted.pdf"', wait=True), 0)
+        trusted_info = self.get_pdfinfo('test.trusted.pdf')
+        self.assertGreaterEqual(int(trusted_info['Pages']), 1)
+
+        self.assertEqual(
+            self.vm.run('test -r "QubesUntrustedPDFs/test.docx"', wait=True), 0)
+        self.assertEqual(self.vm.run(
+            'diff "orig.docx" "QubesUntrustedPDFs/test.docx"', wait=True), 0)
 
 
 def list_tests():

--- a/qubespdfconverter/tests/test_password.py
+++ b/qubespdfconverter/tests/test_password.py
@@ -13,6 +13,7 @@ from unittest import mock
 
 from qubespdfconverter.server import (
     BaseFile,
+    DocxRenderer,
     PdfRenderer,
     create_renderer,
     renderer_name_for_path,
@@ -110,6 +111,14 @@ class TC_ServerPassword(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(renderer.password, b"secret")
         self.assertEqual(renderer.resolution, "200")
 
+    def test_create_renderer_returns_docx_renderer(self):
+        """The server dispatch table creates the DOCX renderer."""
+        with tempfile.NamedTemporaryFile(suffix=".docx") as f:
+            renderer = create_renderer("docx", Path(f.name), resolution=200)
+
+        self.assertIsInstance(renderer, DocxRenderer)
+        self.assertEqual(renderer.resolution, 200)
+
     def test_create_renderer_rejects_unknown_type(self):
         """Unknown renderer names fail before any conversion starts."""
         with tempfile.NamedTemporaryFile(suffix=".pdf") as f:
@@ -126,6 +135,20 @@ class TC_ServerPassword(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(renderer_name, "pdf")
 
+    def test_server_dispatches_docx_mime_to_docx_renderer_name(self):
+        """DOCX MIME detection selects the DOCX renderer on the server side."""
+        mime_type = (
+            "application/vnd.openxmlformats-officedocument." "wordprocessingml.document"
+        )
+
+        with tempfile.NamedTemporaryFile(suffix=".docx") as f, mock.patch(
+            "qubespdfconverter.server.detect_mime",
+            return_value=mime_type,
+        ):
+            renderer_name = renderer_name_for_path(Path(f.name))
+
+        self.assertEqual(renderer_name, "docx")
+
     def test_server_rejects_unsupported_mime(self):
         """Unsupported MIME types fail before selecting a renderer."""
         with tempfile.NamedTemporaryFile(suffix=".txt") as f, mock.patch(
@@ -134,6 +157,38 @@ class TC_ServerPassword(unittest.IsolatedAsyncioTestCase):
         ):
             with self.assertRaises(ValueError):
                 renderer_name_for_path(Path(f.name))
+
+    def test_docx_renderer_converts_to_pdf_before_page_count(self):
+        """DOCX rendering converts through LibreOffice before PDF handling."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir, "source.docx")
+            path.write_bytes(b"docx")
+            renderer = DocxRenderer(path, resolution=200)
+
+            def fake_run(cmd, capture_output, check):
+                if cmd[0] == "libreoffice":
+                    self.assertIn("--headless", cmd)
+                    self.assertIn("--convert-to", cmd)
+                    self.assertIn("pdf", cmd)
+                    Path(cmd[-1]).with_suffix(".pdf").write_bytes(b"%PDF-1.7")
+                    return mock.Mock(stdout=b"")
+
+                self.assertEqual(cmd[0], "pdfinfo")
+                return mock.Mock(stdout=b"Pages:           4\n")
+
+            with mock.patch("subprocess.run", side_effect=fake_run):
+                self.assertEqual(renderer.page_count(), 4)
+
+    def test_docx_renderer_reports_missing_pdf_output(self):
+        """A failed DOCX conversion without PDF output is reported clearly."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir, "source.docx")
+            path.write_bytes(b"docx")
+            renderer = DocxRenderer(path, resolution=200)
+
+            with mock.patch("subprocess.run", return_value=mock.Mock()):
+                with self.assertRaises(ValueError):
+                    renderer.page_count()
 
 
 class TC_ServerBackwardCompat(unittest.TestCase):

--- a/qubespdfconverter/tests/test_password.py
+++ b/qubespdfconverter/tests/test_password.py
@@ -67,8 +67,7 @@ class TC_ServerPassword(unittest.IsolatedAsyncioTestCase):
             mock_proc.wait = mock.AsyncMock(return_value=0)
 
             with mock.patch(
-                "asyncio.create_subprocess_exec",
-                return_value=mock_proc
+                "asyncio.create_subprocess_exec", return_value=mock_proc
             ) as exec_mock:
                 await renderer.create_page_image(1, Path(tmpdir, "1.png"))
 
@@ -89,8 +88,7 @@ class TC_ServerPassword(unittest.IsolatedAsyncioTestCase):
             mock_proc.wait = mock.AsyncMock(return_value=0)
 
             with mock.patch(
-                "asyncio.create_subprocess_exec",
-                return_value=mock_proc
+                "asyncio.create_subprocess_exec", return_value=mock_proc
             ) as exec_mock:
                 await renderer.create_page_image(1, Path(tmpdir, "1.png"))
 
@@ -120,22 +118,20 @@ class TC_ServerPassword(unittest.IsolatedAsyncioTestCase):
 
     def test_server_dispatches_pdf_mime_to_pdf_renderer_name(self):
         """MIME-based renderer selection happens on the server side."""
-        with tempfile.NamedTemporaryFile(suffix=".pdf") as f, \
-             mock.patch(
-                 "qubespdfconverter.server.detect_mime",
-                 return_value="application/pdf",
-             ):
+        with tempfile.NamedTemporaryFile(suffix=".pdf") as f, mock.patch(
+            "qubespdfconverter.server.detect_mime",
+            return_value="application/pdf",
+        ):
             renderer_name = renderer_name_for_path(Path(f.name))
 
         self.assertEqual(renderer_name, "pdf")
 
     def test_server_rejects_unsupported_mime(self):
         """Unsupported MIME types fail before selecting a renderer."""
-        with tempfile.NamedTemporaryFile(suffix=".txt") as f, \
-             mock.patch(
-                 "qubespdfconverter.server.detect_mime",
-                 return_value="text/plain",
-             ):
+        with tempfile.NamedTemporaryFile(suffix=".txt") as f, mock.patch(
+            "qubespdfconverter.server.detect_mime",
+            return_value="text/plain",
+        ):
             with self.assertRaises(ValueError):
                 renderer_name_for_path(Path(f.name))
 
@@ -150,7 +146,7 @@ class TC_ServerBackwardCompat(unittest.TestCase):
         first_line = buf.readline()
 
         if first_line.startswith(b"--password="):
-            password = first_line[len(b"--password="):].rstrip(b"\n")
+            password = first_line[len(b"--password=") :].rstrip(b"\n")
             prefix = b""
         else:
             password = b""
@@ -201,8 +197,9 @@ class TC_ClientPassword(unittest.IsolatedAsyncioTestCase):
         mock_proc.stdin = mock.Mock()
         job.proc = mock_proc
 
-        with mock.patch("qubespdfconverter.client.send", side_effect=fake_send), \
-             mock.patch.object(Path, "read_bytes", return_value=b"%PDF-1.4"):
+        with mock.patch(
+            "qubespdfconverter.client.send", side_effect=fake_send
+        ), mock.patch.object(Path, "read_bytes", return_value=b"%PDF-1.4"):
             await job._send()
 
         self.assertEqual(sent_data[0], "--password=hunter2\n")
@@ -223,8 +220,9 @@ class TC_ClientPassword(unittest.IsolatedAsyncioTestCase):
         mock_proc.stdin = mock.Mock()
         job.proc = mock_proc
 
-        with mock.patch("qubespdfconverter.client.send", side_effect=fake_send), \
-             mock.patch.object(Path, "read_bytes", return_value=b"%PDF-1.4"):
+        with mock.patch(
+            "qubespdfconverter.client.send", side_effect=fake_send
+        ), mock.patch.object(Path, "read_bytes", return_value=b"%PDF-1.4"):
             await job._send()
 
         self.assertEqual(len(sent_data), 1)
@@ -271,8 +269,9 @@ class TC_ClientDetectionAndPrompt(unittest.TestCase):
         result.returncode = 0
         result.stdout = b"secret\n"
 
-        with tempfile.NamedTemporaryFile(suffix=".pdf") as f, \
-             mock.patch("subprocess.run", return_value=result):
+        with tempfile.NamedTemporaryFile(suffix=".pdf") as f, mock.patch(
+            "subprocess.run", return_value=result
+        ):
             password = prompt_password_zenity(Path(f.name))
 
         self.assertEqual(password, "secret")
@@ -285,8 +284,9 @@ class TC_ClientDetectionAndPrompt(unittest.TestCase):
         result.returncode = 1
         result.stdout = b""
 
-        with tempfile.NamedTemporaryFile(suffix=".pdf") as f, \
-             mock.patch("subprocess.run", return_value=result):
+        with tempfile.NamedTemporaryFile(suffix=".pdf") as f, mock.patch(
+            "subprocess.run", return_value=result
+        ):
             password = prompt_password_zenity(Path(f.name))
 
         self.assertIsNone(password)


### PR DESCRIPTION
﻿This adds the first non-PDF `qvm-convert-file` path.

DOCX files are detected on the server/Disposable VM side, converted to an intermediate PDF with LibreOffice headless, then passed through the existing PDF rendering/sanitizing pipeline.

Kept intentionally small: DOCX only for now, so the path can be reviewed before adding ODT/RTF or spreadsheets.

Validation:
- `PYTHONPATH=. python qubespdfconverter/tests/test_password.py`
- `python -m py_compile qubespdfconverter/server.py qubespdfconverter/tests/test_password.py qubespdfconverter/tests/__init__.py`
- `python -m pylint --rcfile=.pylintrc qubespdfconverter/server.py`
- `python -m black --check qubespdfconverter/server.py qubespdfconverter/tests/test_password.py`
- `git diff --check`
