### PR TITLE
pdf-converter: add ODT document conversion

### DIFF
--- a/qubespdfconverter/server.py
+++ b/qubespdfconverter/server.py
@@ -22,6 +22,7 @@
 
 import argparse
 import asyncio
+import functools
 import shutil
 import subprocess
 import sys
@@ -148,20 +149,21 @@ class PdfRenderer:
         return rep
 
 
-class DocxRenderer:
-    """Convert DOCX documents to PDF, then render the PDF pages."""
+class LibreOfficeDocumentRenderer:
+    """Convert office documents to PDF, then render the PDF pages."""
 
-    def __init__(self, path, password=b"", resolution=RESOLUTION):
+    def __init__(self, path, password=b"", resolution=RESOLUTION, suffix=".docx"):
         self.path = path
         self.resolution = resolution
+        self.suffix = suffix
         self._pdf_renderer = None
 
     def pdf_renderer(self):
         if self._pdf_renderer is not None:
             return self._pdf_renderer
 
-        docx_path = Path(self.path.parent, "input.docx")
-        shutil.copyfile(self.path, docx_path)
+        document_path = Path(self.path.parent, "input" + self.suffix)
+        shutil.copyfile(self.path, document_path)
 
         cmd = [
             "libreoffice",
@@ -170,13 +172,13 @@ class DocxRenderer:
             "pdf",
             "--outdir",
             str(self.path.parent),
-            str(docx_path),
+            str(document_path),
         ]
         subprocess.run(cmd, capture_output=True, check=True)
 
-        pdf_path = docx_path.with_suffix(".pdf")
+        pdf_path = document_path.with_suffix(".pdf")
         if not pdf_path.exists():
-            raise ValueError("DOCX conversion did not produce a PDF")
+            raise ValueError("document conversion did not produce a PDF")
 
         self._pdf_renderer = PdfRenderer(pdf_path, resolution=self.resolution)
         return self._pdf_renderer
@@ -191,13 +193,15 @@ class DocxRenderer:
 
 
 RENDERERS = {
-    "docx": DocxRenderer,
+    "docx": functools.partial(LibreOfficeDocumentRenderer, suffix=".docx"),
+    "odt": functools.partial(LibreOfficeDocumentRenderer, suffix=".odt"),
     "pdf": PdfRenderer,
 }
 
 MIME_DISPATCH = {
     "application/pdf": "pdf",
     "application/vnd.openxmlformats-officedocument.wordprocessingml.document": ("docx"),
+    "application/vnd.oasis.opendocument.text": "odt",
 }
 
 

--- a/qubespdfconverter/tests/__init__.py
+++ b/qubespdfconverter/tests/__init__.py
@@ -119,6 +119,52 @@ with zipfile.ZipFile(filename, "w") as docx:
         if p.returncode != 0:
             self.skipTest('failed to create test docx: {}'.format(stdout))
 
+    def create_odt(self, filename, text):
+        '''Create ODT file with given (textual) content
+
+        :param filename: output filename
+        :param text: text to be placed in the document
+        '''
+        script = r'''
+import sys
+import zipfile
+
+filename = sys.argv[1]
+text = sys.argv[2]
+
+manifest = ''' + repr("""<?xml version="1.0" encoding="UTF-8"?>
+<manifest:manifest
+  xmlns:manifest="urn:oasis:names:tc:opendocument:xmlns:manifest:1.0"
+  manifest:version="1.2">
+  <manifest:file-entry manifest:media-type="application/vnd.oasis.opendocument.text" manifest:full-path="/"/>
+  <manifest:file-entry manifest:media-type="text/xml" manifest:full-path="content.xml"/>
+</manifest:manifest>
+""") + r'''
+content = f''' + repr("""<?xml version="1.0" encoding="UTF-8"?>
+<office:document-content
+  xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0"
+  xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0"
+  office:version="1.2">
+  <office:body>
+    <office:text>
+      <text:p>{text}</text:p>
+    </office:text>
+  </office:body>
+</office:document-content>
+""") + r'''.format(text=text)
+
+with zipfile.ZipFile(filename, "w") as odt:
+    odt.writestr("mimetype", "application/vnd.oasis.opendocument.text")
+    odt.writestr("META-INF/manifest.xml", manifest)
+    odt.writestr("content.xml", content)
+'''
+        p = self.vm.run(
+            'python3 - "{}" "{}"'.format(filename, text),
+            passio_popen=True)
+        (stdout, _) = p.communicate(script.encode())
+        if p.returncode != 0:
+            self.skipTest('failed to create test odt: {}'.format(stdout))
+
     def get_pdfinfo(self, filename):
         p = self.vm.run('pdfinfo "{}"'.format(filename), passio_popen=True)
         (stdout, _) = p.communicate()
@@ -231,6 +277,26 @@ with zipfile.ZipFile(filename, "w") as docx:
             self.vm.run('test -r "QubesUntrustedPDFs/test.docx"', wait=True), 0)
         self.assertEqual(self.vm.run(
             'diff "orig.docx" "QubesUntrustedPDFs/test.docx"', wait=True), 0)
+
+    def test_006_odt(self):
+        if self.vm.run('command -v libreoffice >/dev/null', wait=True) != 0:
+            self.skipTest('libreoffice not installed')
+        self.create_odt('test.odt', 'This is test')
+        p = self.vm.run(
+            'cp test.odt orig.odt; qvm-convert-file test.odt 2>&1',
+            passio_popen=True)
+        (stdout, _) = p.communicate()
+        self.assertEqual(
+            p.returncode, 0, 'qvm-convert-file failed: {}'.format(stdout))
+        self.assertEqual(
+            self.vm.run('test -r "test.trusted.pdf"', wait=True), 0)
+        trusted_info = self.get_pdfinfo('test.trusted.pdf')
+        self.assertGreaterEqual(int(trusted_info['Pages']), 1)
+
+        self.assertEqual(
+            self.vm.run('test -r "QubesUntrustedPDFs/test.odt"', wait=True), 0)
+        self.assertEqual(self.vm.run(
+            'diff "orig.odt" "QubesUntrustedPDFs/test.odt"', wait=True), 0)
 
 
 def list_tests():

--- a/qubespdfconverter/tests/test_password.py
+++ b/qubespdfconverter/tests/test_password.py
@@ -13,7 +13,7 @@ from unittest import mock
 
 from qubespdfconverter.server import (
     BaseFile,
-    DocxRenderer,
+    LibreOfficeDocumentRenderer,
     PdfRenderer,
     create_renderer,
     renderer_name_for_path,
@@ -116,8 +116,18 @@ class TC_ServerPassword(unittest.IsolatedAsyncioTestCase):
         with tempfile.NamedTemporaryFile(suffix=".docx") as f:
             renderer = create_renderer("docx", Path(f.name), resolution=200)
 
-        self.assertIsInstance(renderer, DocxRenderer)
+        self.assertIsInstance(renderer, LibreOfficeDocumentRenderer)
         self.assertEqual(renderer.resolution, 200)
+        self.assertEqual(renderer.suffix, ".docx")
+
+    def test_create_renderer_returns_odt_renderer(self):
+        """The server dispatch table creates the ODT renderer."""
+        with tempfile.NamedTemporaryFile(suffix=".odt") as f:
+            renderer = create_renderer("odt", Path(f.name), resolution=200)
+
+        self.assertIsInstance(renderer, LibreOfficeDocumentRenderer)
+        self.assertEqual(renderer.resolution, 200)
+        self.assertEqual(renderer.suffix, ".odt")
 
     def test_create_renderer_rejects_unknown_type(self):
         """Unknown renderer names fail before any conversion starts."""
@@ -149,6 +159,18 @@ class TC_ServerPassword(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(renderer_name, "docx")
 
+    def test_server_dispatches_odt_mime_to_odt_renderer_name(self):
+        """ODT MIME detection selects the shared document renderer."""
+        mime_type = "application/vnd.oasis.opendocument.text"
+
+        with tempfile.NamedTemporaryFile(suffix=".odt") as f, mock.patch(
+            "qubespdfconverter.server.detect_mime",
+            return_value=mime_type,
+        ):
+            renderer_name = renderer_name_for_path(Path(f.name))
+
+        self.assertEqual(renderer_name, "odt")
+
     def test_server_rejects_unsupported_mime(self):
         """Unsupported MIME types fail before selecting a renderer."""
         with tempfile.NamedTemporaryFile(suffix=".txt") as f, mock.patch(
@@ -163,7 +185,7 @@ class TC_ServerPassword(unittest.IsolatedAsyncioTestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             path = Path(tmpdir, "source.docx")
             path.write_bytes(b"docx")
-            renderer = DocxRenderer(path, resolution=200)
+            renderer = LibreOfficeDocumentRenderer(path, resolution=200, suffix=".docx")
 
             def fake_run(cmd, capture_output, check):
                 if cmd[0] == "libreoffice":
@@ -184,11 +206,30 @@ class TC_ServerPassword(unittest.IsolatedAsyncioTestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             path = Path(tmpdir, "source.docx")
             path.write_bytes(b"docx")
-            renderer = DocxRenderer(path, resolution=200)
+            renderer = LibreOfficeDocumentRenderer(path, resolution=200, suffix=".docx")
 
             with mock.patch("subprocess.run", return_value=mock.Mock()):
                 with self.assertRaises(ValueError):
                     renderer.page_count()
+
+    def test_odt_renderer_uses_odt_extension_for_libreoffice(self):
+        """ODT rendering uses the same LibreOffice path with an ODT input."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir, "source.odt")
+            path.write_bytes(b"odt")
+            renderer = LibreOfficeDocumentRenderer(path, resolution=200, suffix=".odt")
+
+            def fake_run(cmd, capture_output, check):
+                if cmd[0] == "libreoffice":
+                    self.assertEqual(Path(cmd[-1]).suffix, ".odt")
+                    Path(cmd[-1]).with_suffix(".pdf").write_bytes(b"%PDF-1.7")
+                    return mock.Mock(stdout=b"")
+
+                self.assertEqual(cmd[0], "pdfinfo")
+                return mock.Mock(stdout=b"Pages:           2\n")
+
+            with mock.patch("subprocess.run", side_effect=fake_run):
+                self.assertEqual(renderer.page_count(), 2)
 
 
 class TC_ServerBackwardCompat(unittest.TestCase):


### PR DESCRIPTION
This extends the merged DOCX path to ODT using the same LibreOffice-backed document renderer class.

What changed:
- Generalized the DOCX renderer into a shared LibreOffice document renderer.
- Added ODT MIME dispatch to the same renderer path.
- Added unit coverage for ODT dispatch/conversion setup and an integration test for `qvm-convert-file test.odt`.

Validation:
- `python -m py_compile qubespdfconverter/server.py qubespdfconverter/tests/test_password.py qubespdfconverter/tests/__init__.py`
- `python -m black --check qubespdfconverter/server.py qubespdfconverter/tests/test_password.py`
- `PYTHONPATH=. python qubespdfconverter/tests/test_password.py`
- `python -m pylint --rcfile=.pylintrc qubespdfconverter/server.py`
- `git diff --check`