### PR TITLE
pdf-converter: add XLSX spreadsheet conversion

### DIFF
--- a/qubespdfconverter/server.py
+++ b/qubespdfconverter/server.py
@@ -196,12 +196,14 @@ RENDERERS = {
     "docx": functools.partial(LibreOfficeDocumentRenderer, suffix=".docx"),
     "odt": functools.partial(LibreOfficeDocumentRenderer, suffix=".odt"),
     "pdf": PdfRenderer,
+    "xlsx": functools.partial(LibreOfficeDocumentRenderer, suffix=".xlsx"),
 }
 
 MIME_DISPATCH = {
     "application/pdf": "pdf",
     "application/vnd.openxmlformats-officedocument.wordprocessingml.document": ("docx"),
     "application/vnd.oasis.opendocument.text": "odt",
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": "xlsx",
 }
 
 

--- a/qubespdfconverter/tests/__init__.py
+++ b/qubespdfconverter/tests/__init__.py
@@ -165,6 +165,69 @@ with zipfile.ZipFile(filename, "w") as odt:
         if p.returncode != 0:
             self.skipTest('failed to create test odt: {}'.format(stdout))
 
+    def create_xlsx(self, filename, text):
+        '''Create XLSX file with given (textual) content
+
+        :param filename: output filename
+        :param text: text to be placed in the spreadsheet
+        '''
+        script = r'''
+import sys
+import zipfile
+
+filename = sys.argv[1]
+text = sys.argv[2]
+
+content_types = ''' + repr("""<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+  <Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+</Types>
+""") + r'''
+rels = ''' + repr("""<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+</Relationships>
+""") + r'''
+workbook_rels = ''' + repr("""<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>
+</Relationships>
+""") + r'''
+workbook = ''' + repr("""<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+  xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <sheets>
+    <sheet name="Sheet1" sheetId="1" r:id="rId1"/>
+  </sheets>
+</workbook>
+""") + r'''
+sheet = f''' + repr("""<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+  <sheetData>
+    <row r="1">
+      <c r="A1" t="inlineStr"><is><t>{text}</t></is></c>
+    </row>
+  </sheetData>
+</worksheet>
+""") + r'''.format(text=text)
+
+with zipfile.ZipFile(filename, "w") as xlsx:
+    xlsx.writestr("[Content_Types].xml", content_types)
+    xlsx.writestr("_rels/.rels", rels)
+    xlsx.writestr("xl/_rels/workbook.xml.rels", workbook_rels)
+    xlsx.writestr("xl/workbook.xml", workbook)
+    xlsx.writestr("xl/worksheets/sheet1.xml", sheet)
+'''
+        p = self.vm.run(
+            'python3 - "{}" "{}"'.format(filename, text),
+            passio_popen=True)
+        (stdout, _) = p.communicate(script.encode())
+        if p.returncode != 0:
+            self.skipTest('failed to create test xlsx: {}'.format(stdout))
+
     def get_pdfinfo(self, filename):
         p = self.vm.run('pdfinfo "{}"'.format(filename), passio_popen=True)
         (stdout, _) = p.communicate()
@@ -297,6 +360,26 @@ with zipfile.ZipFile(filename, "w") as odt:
             self.vm.run('test -r "QubesUntrustedPDFs/test.odt"', wait=True), 0)
         self.assertEqual(self.vm.run(
             'diff "orig.odt" "QubesUntrustedPDFs/test.odt"', wait=True), 0)
+
+    def test_007_xlsx(self):
+        if self.vm.run('command -v libreoffice >/dev/null', wait=True) != 0:
+            self.skipTest('libreoffice not installed')
+        self.create_xlsx('test.xlsx', 'This is test')
+        p = self.vm.run(
+            'cp test.xlsx orig.xlsx; qvm-convert-file test.xlsx 2>&1',
+            passio_popen=True)
+        (stdout, _) = p.communicate()
+        self.assertEqual(
+            p.returncode, 0, 'qvm-convert-file failed: {}'.format(stdout))
+        self.assertEqual(
+            self.vm.run('test -r "test.trusted.pdf"', wait=True), 0)
+        trusted_info = self.get_pdfinfo('test.trusted.pdf')
+        self.assertGreaterEqual(int(trusted_info['Pages']), 1)
+
+        self.assertEqual(
+            self.vm.run('test -r "QubesUntrustedPDFs/test.xlsx"', wait=True), 0)
+        self.assertEqual(self.vm.run(
+            'diff "orig.xlsx" "QubesUntrustedPDFs/test.xlsx"', wait=True), 0)
 
 
 def list_tests():

--- a/qubespdfconverter/tests/test_password.py
+++ b/qubespdfconverter/tests/test_password.py
@@ -129,6 +129,15 @@ class TC_ServerPassword(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(renderer.resolution, 200)
         self.assertEqual(renderer.suffix, ".odt")
 
+    def test_create_renderer_returns_xlsx_renderer(self):
+        """The server dispatch table creates the XLSX renderer."""
+        with tempfile.NamedTemporaryFile(suffix=".xlsx") as f:
+            renderer = create_renderer("xlsx", Path(f.name), resolution=200)
+
+        self.assertIsInstance(renderer, LibreOfficeDocumentRenderer)
+        self.assertEqual(renderer.resolution, 200)
+        self.assertEqual(renderer.suffix, ".xlsx")
+
     def test_create_renderer_rejects_unknown_type(self):
         """Unknown renderer names fail before any conversion starts."""
         with tempfile.NamedTemporaryFile(suffix=".pdf") as f:
@@ -170,6 +179,20 @@ class TC_ServerPassword(unittest.IsolatedAsyncioTestCase):
             renderer_name = renderer_name_for_path(Path(f.name))
 
         self.assertEqual(renderer_name, "odt")
+
+    def test_server_dispatches_xlsx_mime_to_xlsx_renderer_name(self):
+        """XLSX MIME detection selects the shared document renderer."""
+        mime_type = (
+            "application/vnd.openxmlformats-officedocument." "spreadsheetml.sheet"
+        )
+
+        with tempfile.NamedTemporaryFile(suffix=".xlsx") as f, mock.patch(
+            "qubespdfconverter.server.detect_mime",
+            return_value=mime_type,
+        ):
+            renderer_name = renderer_name_for_path(Path(f.name))
+
+        self.assertEqual(renderer_name, "xlsx")
 
     def test_server_rejects_unsupported_mime(self):
         """Unsupported MIME types fail before selecting a renderer."""
@@ -222,6 +245,25 @@ class TC_ServerPassword(unittest.IsolatedAsyncioTestCase):
             def fake_run(cmd, capture_output, check):
                 if cmd[0] == "libreoffice":
                     self.assertEqual(Path(cmd[-1]).suffix, ".odt")
+                    Path(cmd[-1]).with_suffix(".pdf").write_bytes(b"%PDF-1.7")
+                    return mock.Mock(stdout=b"")
+
+                self.assertEqual(cmd[0], "pdfinfo")
+                return mock.Mock(stdout=b"Pages:           2\n")
+
+            with mock.patch("subprocess.run", side_effect=fake_run):
+                self.assertEqual(renderer.page_count(), 2)
+
+    def test_xlsx_renderer_uses_xlsx_extension_for_libreoffice(self):
+        """XLSX rendering uses the same LibreOffice path with an XLSX input."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir, "source.xlsx")
+            path.write_bytes(b"xlsx")
+            renderer = LibreOfficeDocumentRenderer(path, resolution=200, suffix=".xlsx")
+
+            def fake_run(cmd, capture_output, check):
+                if cmd[0] == "libreoffice":
+                    self.assertEqual(Path(cmd[-1]).suffix, ".xlsx")
                     Path(cmd[-1]).with_suffix(".pdf").write_bytes(b"%PDF-1.7")
                     return mock.Mock(stdout=b"")
 


### PR DESCRIPTION
This extends the LibreOffice-backed conversion path to XLSX spreadsheets, using the same shared renderer class as DOCX/ODT.

What changed:

- Added XLSX MIME dispatch to the existing LibreOffice renderer path.
- Added unit coverage for XLSX dispatch and renderer setup.
- Added an integration test for `qvm-convert-file test.xlsx`.

Validation:

- `python -m py_compile qubespdfconverter/server.py qubespdfconverter/tests/test_password.py qubespdfconverter/tests/__init__.py`
- `python -m black --check qubespdfconverter/server.py qubespdfconverter/tests/test_password.py`
- `PYTHONPATH=. python qubespdfconverter/tests/test_password.py`
- `python -m pylint --rcfile=.pylintrc qubespdfconverter/server.py`
- `git diff --check`