### PR TITLE
pdf-converter: add ODS spreadsheet conversion

### DIFF
--- a/qubespdfconverter/server.py
+++ b/qubespdfconverter/server.py
@@ -194,6 +194,7 @@ class LibreOfficeDocumentRenderer:
 
 RENDERERS = {
     "docx": functools.partial(LibreOfficeDocumentRenderer, suffix=".docx"),
+    "ods": functools.partial(LibreOfficeDocumentRenderer, suffix=".ods"),
     "odt": functools.partial(LibreOfficeDocumentRenderer, suffix=".odt"),
     "pdf": PdfRenderer,
     "xlsx": functools.partial(LibreOfficeDocumentRenderer, suffix=".xlsx"),
@@ -202,6 +203,7 @@ RENDERERS = {
 MIME_DISPATCH = {
     "application/pdf": "pdf",
     "application/vnd.openxmlformats-officedocument.wordprocessingml.document": ("docx"),
+    "application/vnd.oasis.opendocument.spreadsheet": "ods",
     "application/vnd.oasis.opendocument.text": "odt",
     "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": "xlsx",
 }

--- a/qubespdfconverter/tests/__init__.py
+++ b/qubespdfconverter/tests/__init__.py
@@ -228,6 +228,59 @@ with zipfile.ZipFile(filename, "w") as xlsx:
         if p.returncode != 0:
             self.skipTest('failed to create test xlsx: {}'.format(stdout))
 
+    def create_ods(self, filename, text):
+        '''Create ODS file with given (textual) content
+
+        :param filename: output filename
+        :param text: text to be placed in the spreadsheet
+        '''
+        script = r'''
+import sys
+import zipfile
+
+filename = sys.argv[1]
+text = sys.argv[2]
+
+manifest = ''' + repr("""<?xml version="1.0" encoding="UTF-8"?>
+<manifest:manifest
+  xmlns:manifest="urn:oasis:names:tc:opendocument:xmlns:manifest:1.0"
+  manifest:version="1.2">
+  <manifest:file-entry manifest:media-type="application/vnd.oasis.opendocument.spreadsheet" manifest:full-path="/"/>
+  <manifest:file-entry manifest:media-type="text/xml" manifest:full-path="content.xml"/>
+</manifest:manifest>
+""") + r'''
+content = f''' + repr("""<?xml version="1.0" encoding="UTF-8"?>
+<office:document-content
+  xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0"
+  xmlns:table="urn:oasis:names:tc:opendocument:xmlns:table:1.0"
+  xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0"
+  office:version="1.2">
+  <office:body>
+    <office:spreadsheet>
+      <table:table table:name="Sheet1">
+        <table:table-row>
+          <table:table-cell office:value-type="string">
+            <text:p>{text}</text:p>
+          </table:table-cell>
+        </table:table-row>
+      </table:table>
+    </office:spreadsheet>
+  </office:body>
+</office:document-content>
+""") + r'''.format(text=text)
+
+with zipfile.ZipFile(filename, "w") as ods:
+    ods.writestr("mimetype", "application/vnd.oasis.opendocument.spreadsheet")
+    ods.writestr("META-INF/manifest.xml", manifest)
+    ods.writestr("content.xml", content)
+'''
+        p = self.vm.run(
+            'python3 - "{}" "{}"'.format(filename, text),
+            passio_popen=True)
+        (stdout, _) = p.communicate(script.encode())
+        if p.returncode != 0:
+            self.skipTest('failed to create test ods: {}'.format(stdout))
+
     def get_pdfinfo(self, filename):
         p = self.vm.run('pdfinfo "{}"'.format(filename), passio_popen=True)
         (stdout, _) = p.communicate()
@@ -380,6 +433,26 @@ with zipfile.ZipFile(filename, "w") as xlsx:
             self.vm.run('test -r "QubesUntrustedPDFs/test.xlsx"', wait=True), 0)
         self.assertEqual(self.vm.run(
             'diff "orig.xlsx" "QubesUntrustedPDFs/test.xlsx"', wait=True), 0)
+
+    def test_008_ods(self):
+        if self.vm.run('command -v libreoffice >/dev/null', wait=True) != 0:
+            self.skipTest('libreoffice not installed')
+        self.create_ods('test.ods', 'This is test')
+        p = self.vm.run(
+            'cp test.ods orig.ods; qvm-convert-file test.ods 2>&1',
+            passio_popen=True)
+        (stdout, _) = p.communicate()
+        self.assertEqual(
+            p.returncode, 0, 'qvm-convert-file failed: {}'.format(stdout))
+        self.assertEqual(
+            self.vm.run('test -r "test.trusted.pdf"', wait=True), 0)
+        trusted_info = self.get_pdfinfo('test.trusted.pdf')
+        self.assertGreaterEqual(int(trusted_info['Pages']), 1)
+
+        self.assertEqual(
+            self.vm.run('test -r "QubesUntrustedPDFs/test.ods"', wait=True), 0)
+        self.assertEqual(self.vm.run(
+            'diff "orig.ods" "QubesUntrustedPDFs/test.ods"', wait=True), 0)
 
 
 def list_tests():

--- a/qubespdfconverter/tests/test_password.py
+++ b/qubespdfconverter/tests/test_password.py
@@ -129,6 +129,15 @@ class TC_ServerPassword(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(renderer.resolution, 200)
         self.assertEqual(renderer.suffix, ".odt")
 
+    def test_create_renderer_returns_ods_renderer(self):
+        """The server dispatch table creates the ODS renderer."""
+        with tempfile.NamedTemporaryFile(suffix=".ods") as f:
+            renderer = create_renderer("ods", Path(f.name), resolution=200)
+
+        self.assertIsInstance(renderer, LibreOfficeDocumentRenderer)
+        self.assertEqual(renderer.resolution, 200)
+        self.assertEqual(renderer.suffix, ".ods")
+
     def test_create_renderer_returns_xlsx_renderer(self):
         """The server dispatch table creates the XLSX renderer."""
         with tempfile.NamedTemporaryFile(suffix=".xlsx") as f:
@@ -179,6 +188,18 @@ class TC_ServerPassword(unittest.IsolatedAsyncioTestCase):
             renderer_name = renderer_name_for_path(Path(f.name))
 
         self.assertEqual(renderer_name, "odt")
+
+    def test_server_dispatches_ods_mime_to_ods_renderer_name(self):
+        """ODS MIME detection selects the shared document renderer."""
+        mime_type = "application/vnd.oasis.opendocument.spreadsheet"
+
+        with tempfile.NamedTemporaryFile(suffix=".ods") as f, mock.patch(
+            "qubespdfconverter.server.detect_mime",
+            return_value=mime_type,
+        ):
+            renderer_name = renderer_name_for_path(Path(f.name))
+
+        self.assertEqual(renderer_name, "ods")
 
     def test_server_dispatches_xlsx_mime_to_xlsx_renderer_name(self):
         """XLSX MIME detection selects the shared document renderer."""
@@ -245,6 +266,25 @@ class TC_ServerPassword(unittest.IsolatedAsyncioTestCase):
             def fake_run(cmd, capture_output, check):
                 if cmd[0] == "libreoffice":
                     self.assertEqual(Path(cmd[-1]).suffix, ".odt")
+                    Path(cmd[-1]).with_suffix(".pdf").write_bytes(b"%PDF-1.7")
+                    return mock.Mock(stdout=b"")
+
+                self.assertEqual(cmd[0], "pdfinfo")
+                return mock.Mock(stdout=b"Pages:           2\n")
+
+            with mock.patch("subprocess.run", side_effect=fake_run):
+                self.assertEqual(renderer.page_count(), 2)
+
+    def test_ods_renderer_uses_ods_extension_for_libreoffice(self):
+        """ODS rendering uses the same LibreOffice path with an ODS input."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir, "source.ods")
+            path.write_bytes(b"ods")
+            renderer = LibreOfficeDocumentRenderer(path, resolution=200, suffix=".ods")
+
+            def fake_run(cmd, capture_output, check):
+                if cmd[0] == "libreoffice":
+                    self.assertEqual(Path(cmd[-1]).suffix, ".ods")
                     Path(cmd[-1]).with_suffix(".pdf").write_bytes(b"%PDF-1.7")
                     return mock.Mock(stdout=b"")
 


### PR DESCRIPTION
This extends the LibreOffice-backed spreadsheet conversion path to ODS, using the same shared renderer class as XLSX/DOCX/ODT.

What changed:

- Added ODS MIME dispatch to the existing LibreOffice renderer path.
- Added unit coverage for ODS dispatch and renderer setup.
- Added an integration test for `qvm-convert-file test.ods`.

Validation:

- `python -m py_compile qubespdfconverter/server.py qubespdfconverter/tests/test_password.py qubespdfconverter/tests/__init__.py`
- `python -m black --check qubespdfconverter/server.py qubespdfconverter/tests/test_password.py`
- `PYTHONPATH=. python qubespdfconverter/tests/test_password.py`
- `python -m pylint --rcfile=.pylintrc qubespdfconverter/server.py`
- `git diff --check`