### PR TITLE
pdf-converter: add qvm-convert-file desktop integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,10 +40,12 @@ install-gnome:
 install-kde4:
 	install -d $(DESTDIR)/usr/share/kde4/services
 	install -m 0644 qvm-convert-pdf.desktop $(DESTDIR)/usr/share/kde4/services
+	install -m 0644 qvm-convert-file.desktop $(DESTDIR)/usr/share/kde4/services
 
 install-pcmanfm-qt:
 	install -d $(DESTDIR)/usr/share/file-manager/actions
 	install -m 0644 qvm-convert-pdf-pcmanfm-qt.desktop $(DESTDIR)/usr/share/file-manager/actions
+	install -m 0644 qvm-convert-file-pcmanfm-qt.desktop $(DESTDIR)/usr/share/file-manager/actions
 
 install-dom0:
 	$(PYTHON) setup.py install -O1 --root $(DESTDIR)

--- a/debian/qubes-pdf-converter.install
+++ b/debian/qubes-pdf-converter.install
@@ -6,7 +6,9 @@ usr/lib/qubes/qvm-convert-pdf.gnome
 usr/share/nautilus-python/extensions
 usr/share/nautilus-python/extensions/qvm_convert_pdf_nautilus.py
 usr/share/kde4/services/qvm-convert-pdf.desktop
+usr/share/kde4/services/qvm-convert-file.desktop
 usr/share/file-manager/actions/qvm-convert-pdf-pcmanfm-qt.desktop
+usr/share/file-manager/actions/qvm-convert-file-pcmanfm-qt.desktop
 usr/share/man/man1/qvm-convert-pdf.1.gz
 usr/lib/python3/dist-packages/qubespdfconverter
 usr/lib/python3/dist-packages/qubespdfconverter-*.egg-info

--- a/qvm-convert-file-pcmanfm-qt.desktop
+++ b/qvm-convert-file-pcmanfm-qt.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Type=Action
+Name=Convert file in disposable qube
+Icon=gtk-convert
+Profiles=on_supported_file;
+
+[X-Action-Profile on_supported_file]
+MimeTypes=application/vnd.openxmlformats-officedocument.wordprocessingml.document;application/vnd.oasis.opendocument.text;application/vnd.openxmlformats-officedocument.spreadsheetml.sheet;application/vnd.oasis.opendocument.spreadsheet;
+Exec=/usr/lib/qubes/qvm-convert-pdf.gnome --file %F

--- a/qvm-convert-file.desktop
+++ b/qvm-convert-file.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Actions=QvmConvertFile;
+Type=Service
+X-KDE-ServiceTypes=KonqPopupMenu/Plugin
+MimeType=application/vnd.openxmlformats-officedocument.wordprocessingml.document;application/vnd.oasis.opendocument.text;application/vnd.openxmlformats-officedocument.spreadsheetml.sheet;application/vnd.oasis.opendocument.spreadsheet;
+
+[Desktop Action QvmConvertFile]
+Exec=/usr/lib/qubes/qvm-convert-pdf.gnome --file %U
+Icon=kget
+Name=Convert to trusted PDF

--- a/qvm-convert-pdf.gnome
+++ b/qvm-convert-pdf.gnome
@@ -22,6 +22,12 @@
 
 set -u
 
+backend="--pdf"
+if [ "${1:-}" = "--pdf" ] || [ "${1:-}" = "--file" ]; then
+    backend="$1"
+    shift
+fi
+
 if [ $# -lt 1 ]; then
 exit 1
 fi
@@ -31,10 +37,18 @@ export PROGRESS_FOR_GUI="yes"
 fifo="$(mktemp -u)"
 mkfifo "$fifo" || exit 1
 
-/usr/bin/qvm-convert-pdf "$@" >"$fifo" &
+if [ "$backend" = "--file" ]; then
+    converter="/usr/bin/qvm-convert-file"
+    progress_text="Converting file using Disposable VM..."
+else
+    converter="/usr/bin/qvm-convert-pdf"
+    progress_text="Converting PDF using Disposable VM..."
+fi
+
+"$converter" "$@" >"$fifo" &
 converter_pid="$!"
 
-zenity --progress --text="Converting PDF using Disposable VM..." --auto-close <"$fifo"
+zenity --progress --text="$progress_text" --auto-close <"$fifo"
 zenity_rc="$?"
 
 rm -f -- "$fifo"

--- a/qvm_convert_pdf_nautilus.py
+++ b/qvm_convert_pdf_nautilus.py
@@ -3,11 +3,14 @@ import os
 from gi.repository import Nautilus, GObject, GLib
 
 
+SUPPORTED_EXTENSIONS = ('.pdf', '.docx', '.odt', '.xlsx', '.ods')
+
+
 class ConvertPdfItemExtension(GObject.GObject, Nautilus.MenuProvider):
-    '''Send PDF to disposable virtual machine to convert to a safe format.
+    '''Send files to disposable virtual machine to convert to a safe format.
 
     Uses the nautilus-python api to provide a context menu within Nautilus which
-    will enable the user to select PDF file(s) to send to a disposable virtual
+    will enable the user to select file(s) to send to a disposable virtual
     machine for safe processing
     '''
 
@@ -31,9 +34,9 @@ class ConvertPdfItemExtension(GObject.GObject, Nautilus.MenuProvider):
             if file_obj.is_directory():
                 continue
 
-            # Only attach context menu to pdf files
-            filename, ext = os.path.splitext(file_obj.get_name())
-            if ext and ext.lower() not in ['.pdf']:
+            # Only attach context menu to supported file types
+            _, ext = os.path.splitext(file_obj.get_name())
+            if ext.lower() not in SUPPORTED_EXTENSIONS:
                 return
 
         menu_item = Nautilus.MenuItem(name='QubesMenuProvider::ConvertPdf',
@@ -47,18 +50,23 @@ class ConvertPdfItemExtension(GObject.GObject, Nautilus.MenuProvider):
     def on_menu_item_clicked(self, menu, files):
         '''Called when user chooses files through Nautilus context menu.
 
-        Collects all selected PDF files and directories into a single
+        Collects all selected files and directories into a single
         qvm-convert-pdf.gnome invocation so one progress window is shown.
         '''
         paths = []
+        backend = '--pdf'
         for file_obj in files:
             if file_obj.is_gone():
                 continue
+            if not file_obj.is_directory():
+                _, ext = os.path.splitext(file_obj.get_name())
+                if ext.lower() != '.pdf':
+                    backend = '--file'
             paths.append(file_obj.get_location().get_path())
 
         if not paths:
             return
 
-        cmd = ['/usr/lib/qubes/qvm-convert-pdf.gnome'] + paths
+        cmd = ['/usr/lib/qubes/qvm-convert-pdf.gnome', backend] + paths
         pid = GLib.spawn_async(cmd)[0]
         GLib.spawn_close_pid(pid)

--- a/rpm_spec/qpdf-converter.spec.in
+++ b/rpm_spec/qpdf-converter.spec.in
@@ -86,8 +86,10 @@ rm -rf $RPM_BUILD_ROOT
 /usr/bin/qvm-convert-file
 /usr/share/nautilus-python/extensions/qvm_convert_pdf_nautilus.py*
 /usr/share/file-manager/actions/qvm-convert-pdf-pcmanfm-qt.desktop
+/usr/share/file-manager/actions/qvm-convert-file-pcmanfm-qt.desktop
 %if !0%{?is_opensuse}
 /usr/share/kde4/services/qvm-convert-pdf.desktop
+/usr/share/kde4/services/qvm-convert-file.desktop
 %endif
 %{_mandir}/man1/qvm-convert-pdf.1*
 %dir %{python3_sitelib}/qubespdfconverter-*.egg-info


### PR DESCRIPTION
This adds file-manager launchers for the generalized `qvm-convert-file` path.

What changed:

- Added a GNOME wrapper for `qvm-convert-file` with the same progress-window flow as the PDF wrapper.
- Added KDE and PCManFM-Qt menu entries for DOCX/ODT/XLSX/ODS MIME types.
- Added a Nautilus context-menu entry for the same supported document/spreadsheet files.
- Installed and packaged the new launcher files.

Validation:

- `python -m py_compile qvm_convert_file_nautilus.py`
- `python -m black --check qvm_convert_file_nautilus.py`
- `git diff --check`