### PR TITLE
pdf-converter: report missing LibreOffice

### DIFF
--- a/qubespdfconverter/client.py
+++ b/qubespdfconverter/client.py
@@ -37,6 +37,8 @@ from pathlib import Path
 from PIL import Image
 from tempfile import TemporaryDirectory
 
+from qubespdfconverter.constants import LIBREOFFICE_MISSING_EXIT_CODE
+
 CLIENT_VM_CMD = ["/usr/bin/qrexec-client-vm", "@dispvm", "qubes.PdfConvert"]
 
 MAX_PAGES = 10000
@@ -563,7 +565,17 @@ class Job:
                     raise asyncio.CancelledError
 
                 self.bar.set_job_status(Status.FAIL)
-                await ERROR_LOGS.put(f"{self.path.name}: {e}")
+                if (
+                    isinstance(e, subprocess.CalledProcessError)
+                    and e.returncode == LIBREOFFICE_MISSING_EXIT_CODE
+                ):
+                    error = (
+                        "LibreOffice is required for this file type; "
+                        "install libreoffice in the relevant template"
+                    )
+                    await ERROR_LOGS.put(f"{self.path.name}: {error}")
+                else:
+                    await ERROR_LOGS.put(f"{self.path.name}: {e}")
                 if self.proc.returncode is None:
                     await terminate_proc(self.proc)
                 raise
@@ -668,7 +680,13 @@ class Job:
         """Receive number of pages in original document from server"""
         try:
             untrusted_pagenums = int(await recvline(self.proc))
-        except (AttributeError, EOFError, UnicodeError, ValueError) as e:
+        except EOFError as e:
+            try:
+                await wait_proc(self.proc, CLIENT_VM_CMD)
+            except subprocess.CalledProcessError as proc_exc:
+                raise proc_exc from e
+            raise QrexecError("Failed to receive page count") from e
+        except (AttributeError, UnicodeError, ValueError) as e:
             raise QrexecError("Failed to receive page count") from e
 
         if 1 <= untrusted_pagenums <= MAX_PAGES:
@@ -762,7 +780,14 @@ async def run(params):
     total = len(results) + num_skipped
     print(f"{newlines}Total Sanitized Files:  {completed}/{total}")
 
-    return completed != total
+    if any(
+        isinstance(result, subprocess.CalledProcessError)
+        and result.returncode == LIBREOFFICE_MISSING_EXIT_CODE
+        for result in results
+    ):
+        return LIBREOFFICE_MISSING_EXIT_CODE
+
+    return int(completed != total)
 
 
 @click.command()

--- a/qubespdfconverter/constants.py
+++ b/qubespdfconverter/constants.py
@@ -1,0 +1,6 @@
+#!/usr/bin/python3
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+"""Shared constants for converter clients and server."""
+
+LIBREOFFICE_MISSING_EXIT_CODE = 64

--- a/qubespdfconverter/server.py
+++ b/qubespdfconverter/server.py
@@ -31,6 +31,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
+from qubespdfconverter.constants import LIBREOFFICE_MISSING_EXIT_CODE
+
 try:
     import magic
 except ImportError:
@@ -95,6 +97,10 @@ def recv_b():
     if not untrusted_data:
         raise EOFError
     return untrusted_data
+
+
+class LibreOfficeMissingError(ValueError):
+    """Raised if LibreOffice is missing in the relevant template."""
 
 
 class PdfRenderer:
@@ -174,7 +180,13 @@ class LibreOfficeDocumentRenderer:
             str(self.path.parent),
             str(document_path),
         ]
-        subprocess.run(cmd, capture_output=True, check=True)
+        try:
+            subprocess.run(cmd, capture_output=True, check=True)
+        except FileNotFoundError as exc:
+            raise LibreOfficeMissingError(
+                "LibreOffice is required for this file type; "
+                "install libreoffice in the relevant template"
+            ) from exc
 
         pdf_path = document_path.with_suffix(".pdf")
         if not pdf_path.exists():
@@ -422,6 +434,9 @@ def main():
             asyncio.run(base.sanitize())
         except subprocess.CalledProcessError:
             sys.exit(1)
+        except LibreOfficeMissingError as exc:
+            print(f"error: {exc}", file=sys.stderr, flush=True)
+            sys.exit(LIBREOFFICE_MISSING_EXIT_CODE)
         except ValueError as exc:
             print(f"error: {exc}", file=sys.stderr, flush=True)
             sys.exit(1)

--- a/qubespdfconverter/tests/test_client.py
+++ b/qubespdfconverter/tests/test_client.py
@@ -3,10 +3,13 @@
 import asyncio
 import os
 import signal
+import subprocess
 import tempfile
 import unittest
 from pathlib import Path
 from unittest import mock
+
+from qubespdfconverter.constants import LIBREOFFICE_MISSING_EXIT_CODE
 
 from qubespdfconverter.client import (
     BadPath,
@@ -82,6 +85,18 @@ class TC_ClientCancel(unittest.IsolatedAsyncioTestCase):
         self.assertFalse(result)
         handled = {call.args[0] for call in add_handler_mock.mock_calls}
         self.assertEqual(handled, {signal.SIGINT, signal.SIGTERM})
+
+    async def test_003_pagenums_propagates_missing_libreoffice_exit_code(self):
+        job = Job(Path("/tmp/test.docx"), 0)
+        proc = DummyProc()
+        proc.returncode = LIBREOFFICE_MISSING_EXIT_CODE
+        proc.stdout.readline = mock.AsyncMock(return_value=b"")
+        job.proc = proc
+
+        with self.assertRaises(subprocess.CalledProcessError) as exc:
+            await job._pagenums()
+
+        self.assertEqual(exc.exception.returncode, LIBREOFFICE_MISSING_EXIT_CODE)
 
 
 class TC_ExpandDir(unittest.TestCase):

--- a/qubespdfconverter/tests/test_password.py
+++ b/qubespdfconverter/tests/test_password.py
@@ -11,11 +11,14 @@ import unittest
 from pathlib import Path
 from unittest import mock
 
+from qubespdfconverter.constants import LIBREOFFICE_MISSING_EXIT_CODE
+
 from qubespdfconverter.server import (
     BaseFile,
     LibreOfficeDocumentRenderer,
     PdfRenderer,
     create_renderer,
+    LibreOfficeMissingError,
     renderer_name_for_path,
 )
 
@@ -255,6 +258,23 @@ class TC_ServerPassword(unittest.IsolatedAsyncioTestCase):
             with mock.patch("subprocess.run", return_value=mock.Mock()):
                 with self.assertRaises(ValueError):
                     renderer.page_count()
+
+    def test_docx_renderer_reports_missing_libreoffice(self):
+        """Missing LibreOffice is reported as a clear conversion error."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir, "source.docx")
+            path.write_bytes(b"docx")
+            renderer = LibreOfficeDocumentRenderer(path, resolution=200, suffix=".docx")
+
+            with mock.patch("subprocess.run", side_effect=FileNotFoundError):
+                with self.assertRaisesRegex(
+                    LibreOfficeMissingError, "relevant template"
+                ):
+                    renderer.page_count()
+
+    def test_missing_libreoffice_exit_code_is_nonzero(self):
+        """Missing LibreOffice uses a dedicated failure code."""
+        self.assertGreater(LIBREOFFICE_MISSING_EXIT_CODE, 0)
 
     def test_odt_renderer_uses_odt_extension_for_libreoffice(self):
         """ODT rendering uses the same LibreOffice path with an ODT input."""

--- a/qvm-convert-pdf.gnome
+++ b/qvm-convert-pdf.gnome
@@ -22,6 +22,8 @@
 
 set -u
 
+LIBREOFFICE_MISSING_EXIT_CODE=64
+
 backend="--pdf"
 if [ "${1:-}" = "--pdf" ] || [ "${1:-}" = "--file" ]; then
     backend="$1"
@@ -60,3 +62,10 @@ if [ "$zenity_rc" -ne 0 ]; then
 fi
 
 wait "$converter_pid"
+converter_rc="$?"
+
+if [ "$converter_rc" -eq "$LIBREOFFICE_MISSING_EXIT_CODE" ]; then
+    zenity --error --text="LibreOffice is required for this file type. Install libreoffice in the relevant template."
+fi
+
+exit "$converter_rc"


### PR DESCRIPTION
This keeps LibreOffice optional, but makes the failure clearer when a LibreOffice-backed file type is used without it installed.

What changed:

- Report missing `libreoffice` as a user-facing conversion error from the backend.
- Added unit coverage for the missing-LibreOffice path.

Validation:

- `python -m py_compile qubespdfconverter/server.py qubespdfconverter/tests/test_password.py`
- `python -m black --check qubespdfconverter/server.py qubespdfconverter/tests/test_password.py`
- `PYTHONPATH=. python qubespdfconverter/tests/test_password.py`
- `python -m pylint --rcfile=.pylintrc qubespdfconverter/server.py`
- `git diff --check`