### PR TITLE
pdf-converter: document qvm-convert-file

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ Usage
 
     Total Sanitized Files: 2/3
 
+The generic `qvm-convert-file` command also supports LibreOffice-backed
+document and spreadsheet conversion for DOCX, ODT, XLSX, and ODS files. Those
+formats require LibreOffice to be installed in the relevant template.
+
 Authors
 ---------
 

--- a/debian/qubes-pdf-converter.install
+++ b/debian/qubes-pdf-converter.install
@@ -10,5 +10,6 @@ usr/share/kde4/services/qvm-convert-file.desktop
 usr/share/file-manager/actions/qvm-convert-pdf-pcmanfm-qt.desktop
 usr/share/file-manager/actions/qvm-convert-file-pcmanfm-qt.desktop
 usr/share/man/man1/qvm-convert-pdf.1.gz
+usr/share/man/man1/qvm-convert-file.1.gz
 usr/lib/python3/dist-packages/qubespdfconverter
 usr/lib/python3/dist-packages/qubespdfconverter-*.egg-info

--- a/doc/qvm-convert-file.rst
+++ b/doc/qvm-convert-file.rst
@@ -1,0 +1,67 @@
+===================
+QVM-CONVERT-FILE(1)
+===================
+
+NAME
+====
+qvm-convert-file - converts potentially untrusted files to safe-to-view PDFs
+
+SYNOPSIS
+========
+:command: `qvm-convert-file` [-h] [--batch SIZE] [--archive PATH] [--in-place]
+                             [--resolution RESOLUTION] [--password PASSWORD]
+                             [FILES ...]
+
+OPTIONS
+========
+
+.. option:: --help, -h
+
+   Show help message and exit
+
+.. option:: --batch=SIZE, -b SIZE
+
+   Maximum number of conversion tasks [x>=1]
+
+.. option:: --archive=PATH, -a PATH
+
+   Directory for storing archived files
+
+.. option:: --in-place, -i
+
+   Replace original files instead of archiving them
+
+.. option:: --resolution=RESOLUTION, -r RESOLUTION
+
+   Output resolution. default is 300 ppi [75<=x<=4800]
+
+.. option:: --password=PASSWORD, -p PASSWORD
+
+   Password to use for encrypted PDF files.
+
+DESCRIPTION
+===========
+
+Qubes file converter is a Qubes Application that uses Qubes' flexible qrexec
+(inter-VM communication) infrastructure and Disposable VMs to convert
+potentially untrusted files into safe-to-view PDF files.
+
+The command supports PDF files directly. It also supports DOCX, ODT, XLSX, and
+ODS files by converting them to an intermediate PDF with LibreOffice inside the
+conversion environment, then using the same bitmap-based PDF conversion
+pipeline.
+
+File type detection is performed on the server side. Unsupported file types are
+rejected instead of being converted.
+
+LibreOffice is optional for PDF conversion, but it is required for the supported
+office document and spreadsheet formats. If LibreOffice is missing, install it
+in the relevant template.
+
+As with qvm-convert-pdf, the converted PDF may be larger than the original file
+and may lose structural information such as searchable text.
+
+AUTHORS
+========
+| Joanna Rutkowska <joanna at invisiblethingslab dot com>
+| Marek Marczykowski <marmarek at invisiblethingslab dot com>

--- a/rpm_spec/qpdf-converter.spec.in
+++ b/rpm_spec/qpdf-converter.spec.in
@@ -92,6 +92,7 @@ rm -rf $RPM_BUILD_ROOT
 /usr/share/kde4/services/qvm-convert-file.desktop
 %endif
 %{_mandir}/man1/qvm-convert-pdf.1*
+%{_mandir}/man1/qvm-convert-file.1*
 %dir %{python3_sitelib}/qubespdfconverter-*.egg-info
 %{python3_sitelib}/qubespdfconverter-*.egg-info/*
 %{python3_sitelib}/qubespdfconverter


### PR DESCRIPTION
This adds user-facing documentation for the generic qvm-convert-file command now that PDF, DOCX, ODT, XLSX, and ODS dispatch are supported. It also updates the Debian and RPM package file lists so the generated qvm-convert-file(1) man page is included.\n\nValidation:\n- git diff --check\n\nI could not build the man pages locally in this Windows shell because make/pandoc are not installed here.