### PR TITLE
pdf-converter: add optional OCR output

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -28,4 +28,7 @@ Recommends:
  zenity
 Suggests:
  python3-nautilus | python-nautilus,
+ libreoffice,
+ python3-fitz,
+ tesseract-ocr-eng,
 Description: The Qubes service for converting untrusted PDF files into trusted ones

--- a/doc/qvm-convert-pdf.rst
+++ b/doc/qvm-convert-pdf.rst
@@ -10,6 +10,7 @@ SYNOPSIS
 ========
 :command: `qvm-convert-pdf` [-h] [--batch SIZE] [--archive PATH] [--in-place]
                             [--resolution RESOLUTION] [--password PASSWORD]
+                            [--ocr-lang LANGUAGE]
 
 OPTIONS
 =======
@@ -38,6 +39,11 @@ OPTIONS
 
    Password to use for encrypted PDF files.
 
+.. option:: --ocr-lang=LANGUAGE
+
+   Tesseract language code to use for OCR output. Tesseract uses three-letter
+   language codes such as ``eng`` for English, not two-letter locale codes.
+
 DESCRIPTION
 ===========
 
@@ -54,6 +60,19 @@ then constructs an entirely new PDF file out of the received bitmaps.
 Of course, the price we pay for this conversion is an increase in file size and 
 the loss of any structural information or text-based search in the converted 
 PDF.
+
+If ``--ocr-lang`` is set, the converter adds a searchable text layer to the
+trusted PDF after the pages have been rendered to safe bitmaps. OCR requires
+PyMuPDF and Tesseract language data in the client qube.
+
+For English OCR, install ``python3-fitz`` and ``tesseract-ocr-eng`` on Debian
+templates, or ``python3-PyMuPDF`` and ``tesseract-langpack-eng`` on Fedora
+templates. Other languages use the same Tesseract three-letter language code in
+the package name.
+
+LibreOffice is required only for LibreOffice-backed input formats handled by
+``qvm-convert-file``. Install the ``libreoffice`` package in the relevant
+template to enable those formats.
 
 AUTHORS
 =======

--- a/qubespdfconverter/client.py
+++ b/qubespdfconverter/client.py
@@ -38,6 +38,7 @@ from PIL import Image
 from tempfile import TemporaryDirectory
 
 from qubespdfconverter.constants import LIBREOFFICE_MISSING_EXIT_CODE
+from qubespdfconverter import ocr
 
 CLIENT_VM_CMD = ["/usr/bin/qrexec-client-vm", "@dispvm", "qubes.PdfConvert"]
 
@@ -173,6 +174,13 @@ def validate_paths(ctx, param, untrusted_paths):
         paths.append(resolved)
 
     return tuple(paths)
+
+
+def validate_ocr_lang(ctx, param, language):
+    try:
+        return ocr.validate_language_code(language)
+    except ValueError as e:
+        raise click.BadParameter(str(e)) from e
 
 
 async def cancel_task(task):
@@ -391,7 +399,7 @@ class BaseFile:
 
     output_resolution: int = RESOLUTION
 
-    def __init__(self, path, pagenums, pdf):
+    def __init__(self, path, pagenums, pdf, ocr_lang=None):
         """
         :param path: @path
         :param pagenums: @pagenums
@@ -400,6 +408,9 @@ class BaseFile:
         self.path = path
         self.pagenums = pagenums
         self.pdf = pdf
+        self.ocr_lang = ocr_lang
+        self.ocr_doc = None
+        self.ocr_tessdata_dir = None
         self.batch = None
 
 
@@ -411,12 +422,21 @@ class BaseFile:
         :param in_place: Value of --in-place flag
         """
         self.batch = asyncio.Queue(depth)
+        if self.ocr_lang:
+            self.ocr_tessdata_dir = ocr.check_available(self.ocr_lang)
+            self.ocr_doc = ocr.create_document()
 
         publish_task = asyncio.create_task(self._publish(proc, bar))
         consume_task = asyncio.create_task(self._consume())
 
         try:
             await asyncio.gather(publish_task, consume_task)
+            if self.ocr_doc is not None:
+                await asyncio.get_running_loop().run_in_executor(
+                    None,
+                    self.ocr_doc.save,
+                    self.pdf
+                )
         finally:
             if not publish_task.done():
                 await cancel_task(publish_task)
@@ -428,6 +448,12 @@ class BaseFile:
                 batch_e = await self.batch.get()
                 await cancel_task(batch_e.task)
                 self.batch.task_done()
+
+            if self.ocr_doc is not None:
+                await asyncio.get_running_loop().run_in_executor(
+                    None,
+                    self.ocr_doc.close
+                )
 
 
     async def _publish(self, proc, bar):
@@ -465,6 +491,10 @@ class BaseFile:
 
     async def _save_reps(self, pages):
         """Save final representations to a PDF file"""
+        if self.ocr_lang:
+            await self._save_ocr_reps(pages)
+            return
+
         images = []
 
         for page in pages:
@@ -512,6 +542,40 @@ class BaseFile:
                 )
 
 
+    async def _save_ocr_reps(self, pages):
+        """Save final representations to a searchable PDF document."""
+        for page in pages:
+            png_path = Path(self.pdf.parent, f"{page}.png")
+            try:
+                page_doc = await asyncio.get_running_loop().run_in_executor(
+                    None,
+                    ocr.png_to_pdf_page,
+                    png_path,
+                    self.ocr_lang,
+                    self.ocr_tessdata_dir,
+                    self.output_resolution,
+                )
+                await asyncio.get_running_loop().run_in_executor(
+                    None,
+                    self.ocr_doc.insert_pdf,
+                    page_doc
+                )
+            except (ocr.OcrDependencyError, RuntimeError, ValueError) as e:
+                raise RepresentationError("Failed to OCR representation") from e
+            finally:
+                try:
+                    await asyncio.get_running_loop().run_in_executor(
+                        None,
+                        page_doc.close
+                    )
+                except (NameError, AttributeError):
+                    pass
+                await asyncio.get_running_loop().run_in_executor(
+                    None,
+                    png_path.unlink
+                )
+
+
 class Job:
     """A sanitization job
 
@@ -519,7 +583,7 @@ class Job:
     :param pos: Bar position
     """
 
-    def __init__(self, path, pos, password=""):
+    def __init__(self, path, pos, password="", ocr_lang=None):
         """
 
         :param file: Base file
@@ -529,6 +593,7 @@ class Job:
         """
         self.path = path
         self.password = password
+        self.ocr_lang = ocr_lang
         self.bar = Tqdm(desc=f"{path}...0/?",
                         bar_format=" {desc}",
                         position=pos)
@@ -604,7 +669,12 @@ class Job:
             self.bar.refresh()
 
         self.pdf = Path(tmpdir, self.path.with_suffix(".trusted.pdf").name)
-        self.base = BaseFile(self.path, pagenums, self.pdf)
+        self.base = BaseFile(
+            self.path,
+            pagenums,
+            self.pdf,
+            ocr_lang=self.ocr_lang
+        )
 
 
     async def _start(self, archive, depth, in_place):
@@ -728,7 +798,10 @@ async def collect_jobs(params):
                 passwords[path] = password
 
     selected_files = [path for path in params["files"] if path not in skipped_files]
-    jobs = [Job(f, i, passwords[f]) for i, f in enumerate(selected_files)]
+    jobs = [
+        Job(f, i, passwords[f], ocr_lang=params.get("ocr_lang"))
+        for i, f in enumerate(selected_files)
+    ]
     tasks = [
         asyncio.create_task(job.run(params["archive"],
                                     params["batch"],
@@ -739,6 +812,13 @@ async def collect_jobs(params):
 
 
 async def run(params):
+    if params.get("ocr_lang"):
+        try:
+            ocr.check_available(params["ocr_lang"])
+        except ocr.OcrDependencyError as e:
+            logging.error(str(e))
+            return 1
+
     CLIENT_VM_CMD[-1] += "+" + str(params["resolution"])
     BaseFile.output_resolution = params["resolution"]
     suffix = "s" if len(params["files"]) > 1 else ""
@@ -828,6 +908,13 @@ async def run(params):
     default="",
     metavar="PASSWORD",
     help="Password for encrypted PDF files"
+)
+@click.option(
+    "--ocr-lang",
+    default=None,
+    callback=validate_ocr_lang,
+    metavar="LANGUAGE",
+    help="Tesseract language code for OCR output"
 )
 @click.argument(
     "files",

--- a/qubespdfconverter/file_client.py
+++ b/qubespdfconverter/file_client.py
@@ -50,6 +50,13 @@ from qubespdfconverter import client as pdf_client
     metavar="PASSWORD",
     help="Password for encrypted PDF files"
 )
+@click.option(
+    "--ocr-lang",
+    default=None,
+    callback=pdf_client.validate_ocr_lang,
+    metavar="LANGUAGE",
+    help="Tesseract language code for OCR output"
+)
 @click.argument(
     "files",
     type=Path,

--- a/qubespdfconverter/ocr.py
+++ b/qubespdfconverter/ocr.py
@@ -1,0 +1,86 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+
+import importlib
+import re
+
+from pathlib import Path
+
+LANG_RE = re.compile(r"^[A-Za-z0-9_]+(?:\+[A-Za-z0-9_]+)*$")
+
+TESSDATA_DIRS = (
+    Path("/usr/share/tessdata"),
+    Path("/usr/share/tesseract/tessdata"),
+    Path("/usr/share/tesseract-ocr/tessdata"),
+    Path("/usr/share/tesseract-ocr/4.00/tessdata"),
+    Path("/usr/share/tesseract-ocr/5/tessdata"),
+)
+
+
+class OcrDependencyError(RuntimeError):
+    """Raised if optional OCR dependencies are missing."""
+
+
+def validate_language_code(language):
+    """Return a validated Tesseract language code."""
+    if not language:
+        return None
+
+    if not LANG_RE.match(language):
+        raise ValueError("OCR language must be a Tesseract language code")
+
+    return language
+
+
+def get_tessdata_dir():
+    """Return a system tessdata directory."""
+    for path in TESSDATA_DIRS:
+        if path.is_dir():
+            return path
+
+    raise OcrDependencyError("Tesseract language data is required for OCR")
+
+
+def check_language_data(language, tessdata_dir):
+    """Check that all requested Tesseract language data files are available."""
+    for lang in language.split("+"):
+        if not (tessdata_dir / f"{lang}.traineddata").is_file():
+            raise OcrDependencyError(
+                f"Tesseract language data for {lang!r} is required for OCR"
+            )
+
+
+def import_fitz():
+    """Import PyMuPDF lazily so OCR remains optional."""
+    try:
+        return importlib.import_module("fitz")
+    except ImportError as exc:
+        raise OcrDependencyError("PyMuPDF is required for OCR") from exc
+
+
+def check_available(language):
+    """Validate optional OCR dependencies before starting conversion."""
+    validate_language_code(language)
+    import_fitz()
+    tessdata_dir = get_tessdata_dir()
+    check_language_data(language, tessdata_dir)
+    return tessdata_dir
+
+
+def create_document():
+    """Create a PyMuPDF document for OCR output."""
+    fitz = import_fitz()
+    return fitz.Document()
+
+
+def png_to_pdf_page(path, language, tessdata_dir, resolution):
+    """Convert a sanitized PNG page to a searchable PDF page."""
+    fitz = import_fitz()
+    pixmap = fitz.Pixmap(str(path))
+    pixmap.set_dpi(resolution, resolution)
+    pdf_bytes = pixmap.pdfocr_tobytes(
+        compress=True,
+        language=language,
+        tessdata=str(tessdata_dir),
+    )
+    return fitz.open("pdf", pdf_bytes)

--- a/qubespdfconverter/tests/test_client.py
+++ b/qubespdfconverter/tests/test_client.py
@@ -9,16 +9,21 @@ import unittest
 from pathlib import Path
 from unittest import mock
 
+import click
+
 from qubespdfconverter.constants import LIBREOFFICE_MISSING_EXIT_CODE
 
 from qubespdfconverter.client import (
     BadPath,
+    BaseFile,
     Job,
     PageError,
     expand_dir,
     run,
+    validate_ocr_lang,
     validate_paths,
 )
+from qubespdfconverter.ocr import OcrDependencyError
 
 
 class DummyProc:
@@ -79,6 +84,7 @@ class TC_ClientCancel(unittest.IsolatedAsyncioTestCase):
                     "archive": Path("/tmp/archive"),
                     "batch": 1,
                     "in_place": False,
+                    "ocr_lang": None,
                 }
             )
 
@@ -97,6 +103,46 @@ class TC_ClientCancel(unittest.IsolatedAsyncioTestCase):
             await job._pagenums()
 
         self.assertEqual(exc.exception.returncode, LIBREOFFICE_MISSING_EXIT_CODE)
+
+    async def test_004_ocr_dependency_error_stops_before_qrexec(self):
+        with mock.patch(
+            "qubespdfconverter.client.ocr.check_available",
+            side_effect=OcrDependencyError("missing OCR dependency"),
+        ), mock.patch("asyncio.create_subprocess_exec") as create_mock:
+            result = await run(
+                {
+                    "resolution": 300,
+                    "files": [Path("/tmp/test.pdf")],
+                    "archive": Path("/tmp/archive"),
+                    "batch": 1,
+                    "in_place": False,
+                    "ocr_lang": "eng",
+                }
+            )
+
+        self.assertEqual(result, 1)
+        create_mock.assert_not_called()
+
+    async def test_005_ocr_reps_insert_pages_into_ocr_document(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            pdf = Path(tmpdir, "out.pdf")
+            png = Path(tmpdir, "1.png")
+            png.write_bytes(b"png")
+            base = BaseFile(Path("/tmp/test.pdf"), 1, pdf, ocr_lang="eng")
+            base.ocr_doc = mock.Mock()
+            base.ocr_tessdata_dir = Path("/tmp/tessdata")
+            page_doc = mock.Mock()
+
+            with mock.patch(
+                "qubespdfconverter.client.ocr.png_to_pdf_page",
+                return_value=page_doc,
+            ) as ocr_mock:
+                await base._save_ocr_reps([1])
+
+        ocr_mock.assert_called_once_with(png, "eng", Path("/tmp/tessdata"), 300)
+        base.ocr_doc.insert_pdf.assert_called_once_with(page_doc)
+        page_doc.close.assert_called_once()
+        self.assertFalse(png.exists())
 
 
 class TC_ExpandDir(unittest.TestCase):
@@ -198,6 +244,21 @@ class TC_ValidatePaths(unittest.TestCase):
         b = self._touch("b.pdf")
         result = validate_paths(None, None, [a, b])
         self.assertEqual(set(result), {a.resolve(), b.resolve()})
+
+
+class TC_OcrLang(unittest.TestCase):
+    def test_000_empty_language_returns_none(self):
+        self.assertIsNone(validate_ocr_lang(None, None, None))
+
+    def test_001_valid_language_returned(self):
+        self.assertEqual(validate_ocr_lang(None, None, "eng"), "eng")
+
+    def test_002_multiple_languages_returned(self):
+        self.assertEqual(validate_ocr_lang(None, None, "eng+hin"), "eng+hin")
+
+    def test_003_invalid_language_raises_bad_parameter(self):
+        with self.assertRaises(click.BadParameter):
+            validate_ocr_lang(None, None, "eng;rm")
 
 
 if __name__ == "__main__":

--- a/qubespdfconverter/tests/test_file_client.py
+++ b/qubespdfconverter/tests/test_file_client.py
@@ -58,6 +58,25 @@ class TC_FileClient(unittest.TestCase):
 
         self.assertNotEqual(result.exit_code, 0)
 
+    def test_ocr_lang_is_forwarded(self):
+        runner = CliRunner()
+
+        with runner.isolated_filesystem():
+            Path("report.pdf").write_bytes(b"%PDF-1.7\n")
+
+            with mock.patch(
+                "qubespdfconverter.file_client.pdf_client.run",
+                new=mock.AsyncMock(return_value=False),
+            ) as run_mock:
+                result = runner.invoke(
+                    file_client.main,
+                    ["--ocr-lang", "eng", "report.pdf"]
+                )
+
+        self.assertEqual(result.exit_code, 0)
+        params = run_mock.await_args.args[0]
+        self.assertEqual(params["ocr_lang"], "eng")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/rpm_spec/qpdf-converter.spec.in
+++ b/rpm_spec/qpdf-converter.spec.in
@@ -56,6 +56,9 @@ Requires:	python%{python3_pkgversion}-click
 Requires:	python%{python3_pkgversion}-magic
 Requires:	python%{python3_pkgversion}-tqdm
 Recommends:	zenity
+Suggests:	libreoffice
+Suggests:	python%{python3_pkgversion}-PyMuPDF
+Suggests:	tesseract-langpack-eng
 
 Source0: %{name}-%{version}.tar.gz
 


### PR DESCRIPTION
This starts the OCR direction 

It adds an optional `--ocr-lang` flag to `qvm-convert-pdf` and `qvm-convert-file`. OCR is disabled by default, so the existing conversion path stays unchanged. When the flag is used, OCR runs only after the file has already been converted into sanitized page bitmaps, then adds a searchable text layer to the trusted PDF.

I also added a small OCR helper, dependency checks before starting the conversion, docs for the new flag, and focused tests for the new path.

Validation:
- `python -m py_compile ...`
- `python -m pylint --rcfile=.pylintrc ...`
- `git diff --check`
- focused OCR tests passed
