### PR TITLE
pdf-converter: enable GUI OCR automatically

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,8 @@ install-service:
 install-gnome:
 	install -d $(DESTDIR)/usr/share/nautilus-python/extensions
 	install -m 0644 qvm_convert_pdf_nautilus.py $(DESTDIR)/usr/share/nautilus-python/extensions
+	install -d $(DESTDIR)/usr/share/applications
+	install -m 0644 qvm-convert-pdf-ocr-settings.desktop $(DESTDIR)/usr/share/applications
 
 install-kde4:
 	install -d $(DESTDIR)/usr/share/kde4/services
@@ -52,6 +54,7 @@ install-dom0:
 	# not needed in dom0
 	rm -f $(DESTDIR)/usr/bin/qvm-convert-pdf
 	rm -f $(DESTDIR)/usr/bin/qvm-convert-file
+	rm -f $(DESTDIR)/usr/bin/qvm-convert-pdf-ocr-settings
 	rm -f $(DESTDIR)/usr/lib/qubes/qpdf-convert-server
 
 clean:

--- a/debian/qubes-pdf-converter.install
+++ b/debian/qubes-pdf-converter.install
@@ -2,9 +2,11 @@ usr/lib/qubes/qpdf-convert-server
 etc/qubes-rpc/qubes.PdfConvert
 usr/bin/qvm-convert-pdf
 usr/bin/qvm-convert-file
+usr/bin/qvm-convert-pdf-ocr-settings
 usr/lib/qubes/qvm-convert-pdf.gnome
 usr/share/nautilus-python/extensions
 usr/share/nautilus-python/extensions/qvm_convert_pdf_nautilus.py
+usr/share/applications/qvm-convert-pdf-ocr-settings.desktop
 usr/share/kde4/services/qvm-convert-pdf.desktop
 usr/share/kde4/services/qvm-convert-file.desktop
 usr/share/file-manager/actions/qvm-convert-pdf-pcmanfm-qt.desktop

--- a/doc/qvm-convert-file.rst
+++ b/doc/qvm-convert-file.rst
@@ -10,7 +10,7 @@ SYNOPSIS
 ========
 :command: `qvm-convert-file` [-h] [--batch SIZE] [--archive PATH] [--in-place]
                              [--resolution RESOLUTION] [--password PASSWORD]
-                             [FILES ...]
+                             [--ocr-lang LANGUAGE] [FILES ...]
 
 OPTIONS
 ========
@@ -39,6 +39,11 @@ OPTIONS
 
    Password to use for encrypted PDF files.
 
+.. option:: --ocr-lang=LANGUAGE
+
+   Tesseract language code to use for OCR output. Tesseract uses three-letter
+   language codes such as ``eng`` for English, not two-letter locale codes.
+
 DESCRIPTION
 ===========
 
@@ -60,6 +65,11 @@ in the relevant template.
 
 As with qvm-convert-pdf, the converted PDF may be larger than the original file
 and may lose structural information such as searchable text.
+
+If ``--ocr-lang`` is set, the converter adds a searchable text layer to the
+trusted PDF after the pages have been rendered to safe bitmaps. If
+``--ocr-lang`` is not set, the command uses the OCR setting saved by
+``qvm-convert-pdf-ocr-settings``.
 
 AUTHORS
 ========

--- a/doc/qvm-convert-pdf.rst
+++ b/doc/qvm-convert-pdf.rst
@@ -74,6 +74,11 @@ LibreOffice is required only for LibreOffice-backed input formats handled by
 ``qvm-convert-file``. Install the ``libreoffice`` package in the relevant
 template to enable those formats.
 
+If ``--ocr-lang`` is not set, the command uses the OCR setting saved by
+``qvm-convert-pdf-ocr-settings``. The graphical file manager action asks for
+this setting the first time it is used, and the settings tool can be launched
+later from the application menu.
+
 AUTHORS
 =======
 | Joanna Rutkowska <joanna at invisiblethingslab dot com>

--- a/qubespdfconverter/client.py
+++ b/qubespdfconverter/client.py
@@ -38,7 +38,7 @@ from PIL import Image
 from tempfile import TemporaryDirectory
 
 from qubespdfconverter.constants import LIBREOFFICE_MISSING_EXIT_CODE
-from qubespdfconverter import ocr
+from qubespdfconverter import ocr, ocr_config
 
 CLIENT_VM_CMD = ["/usr/bin/qrexec-client-vm", "@dispvm", "qubes.PdfConvert"]
 
@@ -811,13 +811,24 @@ async def collect_jobs(params):
     return jobs, tasks, len(skipped_files)
 
 
-async def run(params):
+def apply_ocr_default(params):
+    """Use configured OCR settings if no OCR language was passed."""
+    if params.get("ocr_lang") is None:
+        params["ocr_lang"] = ocr_config.get_default_ocr_lang()
+
     if params.get("ocr_lang"):
         try:
             ocr.check_available(params["ocr_lang"])
         except ocr.OcrDependencyError as e:
             logging.error(str(e))
-            return 1
+            return False
+
+    return True
+
+
+async def run(params):
+    if not apply_ocr_default(params):
+        return 1
 
     CLIENT_VM_CMD[-1] += "+" + str(params["resolution"])
     BaseFile.output_resolution = params["resolution"]

--- a/qubespdfconverter/ocr_config.py
+++ b/qubespdfconverter/ocr_config.py
@@ -1,0 +1,75 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+
+import configparser
+import os
+
+from pathlib import Path
+
+from qubespdfconverter import ocr
+
+CONFIG_DIR = "qubes-pdf-converter"
+CONFIG_NAME = "ocr.conf"
+SECTION = "ocr"
+DEFAULT_LANGUAGE = "eng"
+
+
+def config_path():
+    """Return the OCR config path."""
+    config_home = os.environ.get("XDG_CONFIG_HOME")
+    if config_home:
+        base = Path(config_home)
+    else:
+        base = Path.home() / ".config"
+    return base / CONFIG_DIR / CONFIG_NAME
+
+
+def read_config(path=None):
+    """Read OCR config from disk."""
+    path = path or config_path()
+    if not path.exists():
+        return None
+
+    parser = configparser.ConfigParser()
+    parser.read(path)
+    if not parser.has_section(SECTION):
+        return None
+
+    enabled = parser.getboolean(SECTION, "enabled", fallback=False)
+    language = parser.get(SECTION, "language", fallback=DEFAULT_LANGUAGE)
+    language = ocr.validate_language_code(language) or DEFAULT_LANGUAGE
+    return enabled, language
+
+
+def write_config(enabled, language=DEFAULT_LANGUAGE, path=None):
+    """Write OCR config to disk."""
+    path = path or config_path()
+    language = ocr.validate_language_code(language) or DEFAULT_LANGUAGE
+
+    parser = configparser.ConfigParser()
+    parser[SECTION] = {
+        "enabled": "yes" if enabled else "no",
+        "language": language,
+    }
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as config_file:
+        parser.write(config_file)
+
+
+def get_default_ocr_lang(path=None):
+    """Return configured OCR language, or None if OCR is disabled/unconfigured."""
+    config = read_config(path)
+    if config is None:
+        return None
+
+    enabled, language = config
+    if not enabled:
+        return None
+    return language
+
+
+def config_exists(path=None):
+    """Return whether OCR config exists."""
+    path = path or config_path()
+    return path.exists()

--- a/qubespdfconverter/ocr_settings.py
+++ b/qubespdfconverter/ocr_settings.py
@@ -1,0 +1,92 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+
+import argparse
+import subprocess
+import sys
+
+from qubespdfconverter import ocr, ocr_config
+
+
+def zenity_question(text):
+    cmd = ["zenity", "--question", f"--text={text}"]
+    return subprocess.run(cmd, check=False).returncode
+
+
+def zenity_language(default):
+    cmd = [
+        "zenity",
+        "--entry",
+        "--title=OCR settings",
+        "--text=Tesseract language code",
+        f"--entry-text={default}",
+    ]
+    proc = subprocess.run(cmd, capture_output=True, check=False)
+    if proc.returncode != 0:
+        return None
+    return proc.stdout.decode("utf-8", errors="ignore").strip()
+
+
+def configure():
+    current = ocr_config.read_config()
+    if current is None:
+        language = ocr_config.DEFAULT_LANGUAGE
+    else:
+        _enabled, language = current
+
+    question = (
+        "Enable OCR for converted PDFs?\n\n"
+        "OCR adds a searchable text layer when Tesseract language data is "
+        "installed."
+    )
+    rc = zenity_question(question)
+    if rc == 1:
+        ocr_config.write_config(False, language)
+        return 0
+    if rc != 0:
+        return rc
+
+    language = zenity_language(language)
+    if language is None:
+        return 1
+
+    try:
+        ocr.validate_language_code(language)
+    except ValueError:
+        subprocess.run(
+            ["zenity", "--error", "--text=Invalid OCR language code."],
+            check=False,
+        )
+        return 1
+
+    ocr_config.write_config(True, language)
+    return 0
+
+
+def print_args(configure_missing=False):
+    if not ocr_config.config_exists():
+        if not configure_missing:
+            return 1
+        if configure() != 0:
+            return 1
+
+    language = ocr_config.get_default_ocr_lang()
+    if language:
+        print(f"--ocr-lang\n{language}")
+    return 0
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Configure PDF converter OCR")
+    parser.add_argument("--print-args", action="store_true")
+    parser.add_argument("--configure-missing", action="store_true")
+    args = parser.parse_args()
+
+    if args.print_args:
+        return print_args(args.configure_missing)
+
+    return configure()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/qubespdfconverter/tests/test_client.py
+++ b/qubespdfconverter/tests/test_client.py
@@ -12,12 +12,14 @@ from unittest import mock
 import click
 
 from qubespdfconverter.constants import LIBREOFFICE_MISSING_EXIT_CODE
+from qubespdfconverter import ocr_config
 
 from qubespdfconverter.client import (
     BadPath,
     BaseFile,
     Job,
     PageError,
+    apply_ocr_default,
     expand_dir,
     run,
     validate_ocr_lang,
@@ -144,6 +146,21 @@ class TC_ClientCancel(unittest.IsolatedAsyncioTestCase):
         page_doc.close.assert_called_once()
         self.assertFalse(png.exists())
 
+    async def test_006_cli_uses_configured_ocr_default(self):
+        params = {"ocr_lang": None}
+
+        with mock.patch(
+            "qubespdfconverter.client.ocr_config.get_default_ocr_lang",
+            return_value="eng",
+        ), mock.patch(
+            "qubespdfconverter.client.ocr.check_available"
+        ) as check_mock:
+            result = apply_ocr_default(params)
+
+        self.assertTrue(result)
+        self.assertEqual(params["ocr_lang"], "eng")
+        check_mock.assert_called_once_with("eng")
+
 
 class TC_ExpandDir(unittest.TestCase):
     def setUp(self):
@@ -259,6 +276,30 @@ class TC_OcrLang(unittest.TestCase):
     def test_003_invalid_language_raises_bad_parameter(self):
         with self.assertRaises(click.BadParameter):
             validate_ocr_lang(None, None, "eng;rm")
+
+
+class TC_OcrConfig(unittest.TestCase):
+    def test_000_missing_config_disables_ocr(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir, "missing.conf")
+            self.assertIsNone(ocr_config.read_config(path))
+            self.assertIsNone(ocr_config.get_default_ocr_lang(path))
+
+    def test_001_write_enabled_config(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir, "ocr.conf")
+            ocr_config.write_config(True, "eng", path)
+
+            self.assertEqual(ocr_config.read_config(path), (True, "eng"))
+            self.assertEqual(ocr_config.get_default_ocr_lang(path), "eng")
+
+    def test_002_write_disabled_config(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir, "ocr.conf")
+            ocr_config.write_config(False, "eng", path)
+
+            self.assertEqual(ocr_config.read_config(path), (False, "eng"))
+            self.assertIsNone(ocr_config.get_default_ocr_lang(path))
 
 
 if __name__ == "__main__":

--- a/qvm-convert-pdf-ocr-settings.desktop
+++ b/qvm-convert-pdf-ocr-settings.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Type=Application
+Name=Qubes PDF converter OCR settings
+Comment=Configure OCR for trusted PDF conversion
+Exec=qvm-convert-pdf-ocr-settings
+Icon=gtk-convert
+Categories=Settings;Utility;

--- a/qvm-convert-pdf.gnome
+++ b/qvm-convert-pdf.gnome
@@ -47,8 +47,17 @@ else
     progress_text="Converting PDF using Disposable VM..."
 fi
 
-"$converter" "$@" >"$fifo" &
+ocr_args_file="$(mktemp)"
+qvm-convert-pdf-ocr-settings --print-args --configure-missing >"$ocr_args_file"
+ocr_args_rc="$?"
+
+if [ "$ocr_args_rc" -eq 0 ] && [ -s "$ocr_args_file" ]; then
+    "$converter" $(cat "$ocr_args_file") "$@" >"$fifo" &
+else
+    "$converter" "$@" >"$fifo" &
+fi
 converter_pid="$!"
+rm -f -- "$ocr_args_file"
 
 zenity --progress --text="$progress_text" --auto-close <"$fifo"
 zenity_rc="$?"

--- a/rpm_spec/qpdf-converter.spec.in
+++ b/rpm_spec/qpdf-converter.spec.in
@@ -87,7 +87,9 @@ rm -rf $RPM_BUILD_ROOT
 /usr/lib/qubes/qvm-convert-pdf.gnome
 /usr/bin/qvm-convert-pdf
 /usr/bin/qvm-convert-file
+/usr/bin/qvm-convert-pdf-ocr-settings
 /usr/share/nautilus-python/extensions/qvm_convert_pdf_nautilus.py*
+/usr/share/applications/qvm-convert-pdf-ocr-settings.desktop
 /usr/share/file-manager/actions/qvm-convert-pdf-pcmanfm-qt.desktop
 /usr/share/file-manager/actions/qvm-convert-file-pcmanfm-qt.desktop
 %if !0%{?is_opensuse}

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,10 @@ class CustomInstall(setuptools.command.install.install):
             ('usr/lib/qubes/qpdf-convert-server', 'qubespdfconverter.server'),
             ('usr/bin/qvm-convert-pdf', 'qubespdfconverter.client'),
             ('usr/bin/qvm-convert-file', 'qubespdfconverter.file_client'),
+            (
+                'usr/bin/qvm-convert-pdf-ocr-settings',
+                'qubespdfconverter.ocr_settings'
+            ),
         ]
         for file, pkg in scripts:
             path = os.path.join(self.root, file)


### PR DESCRIPTION
This follows up on the OCR GUI discussion.

It replaces the automatic dependency-based OCR behavior with a small OCR settings flow:

- OCR settings are saved in a user config file.
- The GUI wrapper opens the settings dialog the first time the config is missing.
- A desktop entry is installed so the setting can be changed later from the menu.
- The CLI uses the saved OCR setting as its default when `--ocr-lang` is not passed.

Validation:
- `python -m py_compile ...`
- `python -m pylint --rcfile=.pylintrc ...`
- `bash -n qvm-convert-pdf.gnome`
- `git diff --check`
- focused OCR config tests passed
