### PR TITLE
pdf-converter: document supported formats

### DIFF
--- a/doc/qvm-convert-file.rst
+++ b/doc/qvm-convert-file.rst
@@ -51,10 +51,23 @@ Qubes file converter is a Qubes Application that uses Qubes' flexible qrexec
 (inter-VM communication) infrastructure and Disposable VMs to convert
 potentially untrusted files into safe-to-view PDF files.
 
-The command supports PDF files directly. It also supports DOCX, ODT, XLSX, and
-ODS files by converting them to an intermediate PDF with LibreOffice inside the
-conversion environment, then using the same bitmap-based PDF conversion
-pipeline.
+Supported input formats:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Format
+     - Notes
+   * - PDF
+     - Converted directly with the PDF rendering pipeline.
+   * - DOCX, ODT
+     - Converted through LibreOffice, then through the PDF rendering pipeline.
+   * - XLSX, ODS
+     - Converted through LibreOffice, then through the PDF rendering pipeline.
+
+For LibreOffice-backed formats, the converter first creates an intermediate PDF
+inside the conversion environment, then uses the same bitmap-based PDF
+conversion pipeline.
 
 File type detection is performed on the server side. Unsupported file types are
 rejected instead of being converted.
@@ -70,6 +83,10 @@ If ``--ocr-lang`` is set, the converter adds a searchable text layer to the
 trusted PDF after the pages have been rendered to safe bitmaps. If
 ``--ocr-lang`` is not set, the command uses the OCR setting saved by
 ``qvm-convert-pdf-ocr-settings``.
+
+OCR is optional. For English OCR, install ``python3-fitz`` and
+``tesseract-ocr-eng`` on Debian templates, or ``python3-PyMuPDF`` and
+``tesseract-langpack-eng`` on Fedora templates.
 
 AUTHORS
 ========

--- a/doc/qvm-convert-pdf.rst
+++ b/doc/qvm-convert-pdf.rst
@@ -52,6 +52,10 @@ Qubes PDF converter is a Qubes Application that utilizes Qubes' flexible qrexec
 potentially untrusted (e.g. maliciously malformed) PDF files into safe-to-view
 PDF files.
 
+For other supported file types, use ``qvm-convert-file``. It currently handles
+PDF, DOCX, ODT, XLSX, and ODS inputs, with LibreOffice required only for the
+Office document and spreadsheet formats.
+
 This is done by having a Disposable VM render each page of a PDF file into a 
 very simple representation (RGB bitmap) that (presumably) leaves no room for 
 malicious code. This representation is then sent back to the client AppVM which 


### PR DESCRIPTION
This is a small docs polish PR after the format and OCR work.

It adds a supported-format summary to qvm-convert-file(1), points qvm-convert-pdf(1) to the generic command, and notes the optional OCR packages.

Validation:
- git diff --check

I could not build the man pages locally because make/pandoc are not installed in this Windows shell.