### PR TITLE
Build docs with Sphinx instead of Pandoc

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,13 @@
+version: 2
+build:
+  os: "ubuntu-lts-latest"
+  tools:
+    python: "3.13"
+
+sphinx:
+  configuration: doc/conf.py
+  fail_on_warning: true
+
+python:
+  install:
+  - requirements: ci/requirements.txt

--- a/archlinux/PKGBUILD.in
+++ b/archlinux/PKGBUILD.in
@@ -5,7 +5,7 @@ arch=(x86_64)
 pkgdesc=$(grep "Summary:" ./rpm_spec/qpdf-converter.spec.in | sed 's/Summary://' | xargs)
 url="https://www.qubes-os.org/"
 license=(GPL)
-makedepends=(git pandoc python-setuptools)
+makedepends=(git python-sphinx python-setuptools)
 depends=(
     graphicsmagick
     poppler

--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,7 @@ Build-Depends:
  debhelper (>= 9~),
  dh-python,
  python3-setuptools,
- pandoc,
+ python3-sphinx,
  quilt
 X-Python-Version: 2.7
 Standards-Version: 3.9.5

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,23 +1,26 @@
-PANDOC=pandoc -s -f rst -t man
+SPHINXBUILD   = sphinx-build
+BUILDDIR      = _build/man
 
-DOCS=$(patsubst %.rst,%.1.gz,$(wildcard *.rst))
-
+.PHONY: help
 help:
-	@echo "make rst=example.rst preview	-- generate manpage preview from example.rst"
 	@echo "make manpages			-- generate manpages"
 	@echo "make install			-- generate manpages and copy them to /usr/share/man"
+	@echo "make clean 			-- remove generated manpages in build directory"
 
+.PHONY: manpages
+manpages:
+	$(SPHINXBUILD) -b man . $(BUILDDIR)
+	for file in $(BUILDDIR)/*.[12345678]; do \
+		gzip -f $$file; \
+	done
+	@echo
+	@echo "Build finished. The manual pages are in $(BUILDDIR)."
+
+.PHONY: install
 install: manpages
 	install -d $(DESTDIR)/usr/share/man/man1
-	install -D $(DOCS) $(DESTDIR)/usr/share/man/man1/
+	install -D $(BUILDDIR)/* $(DESTDIR)/usr/share/man/man1/
 
-%.1: %.rst
-	$(PANDOC) $< > $@
-
-%.1.gz: %.1
-	gzip -f $<
-
-manpages: $(DOCS)
-
+.PHONY: clean
 clean:
-	rm -f $(DOCS)
+	rm -f $(BUILDDIR)

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,0 +1,63 @@
+import os
+import subprocess
+import sys
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+sys.path.insert(0, os.path.abspath("../"))
+sys.path.insert(1, os.path.abspath("../test-packages"))
+
+# -- Project information -----------------------------------------------------
+
+project = "app-linux-pdf-converter"
+author = "Qubes OS Project"
+copyright = "2010-%Y, Invisible Things Lab"
+
+# The version info for the project you're documenting, acts as replacement for
+# |version| and |release|, also used in various other places throughout the
+# built documents.
+#
+# The short X.Y version.
+version = open("../version").read().strip()
+# The full version, including alpha/beta/rc tags.
+try:
+    release = (
+        subprocess.check_output(["git", "describe", "--long", "--dirty"])
+        .strip()
+        .decode()
+    )
+except:
+    release = "1"
+
+# -- General configuration ---------------------------------------------------
+
+extensions = [
+    "sphinx.ext.intersphinx",  # Reference other doc projects
+]
+
+# -- Extensions configuration ------------------------------------------------
+# Allows references to the docs in dev.qubes-os.org
+# i.e.: :doc:`core-admin:libvirt`
+intersphinx_mapping = {
+    "qubes-doc": ("https://doc.qubes-os.org/en/latest/", None),
+    "core-admin": ("https://dev.qubes-os.org/projects/core-admin/en/latest/", None),
+    "core-admin-client": (
+        "https://dev.qubes-os.org/projects/core-admin-client/en/latest/",
+        None,
+    ),
+    "core-qrexec": (
+        "https://dev.qubes-os.org/projects/qubes-core-qrexec/en/stable/",
+        None,
+    ),
+}
+
+intersphinx_disabled_reftypes = []
+
+# -- Options for markup --------------------------------------------------------
+
+option_emphasise_placeholders = True
+
+# -- -- Options for the nitpicky mode ------------------------------------------
+
+nitpicky = True

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -61,3 +61,14 @@ option_emphasise_placeholders = True
 # -- -- Options for the nitpicky mode ------------------------------------------
 
 nitpicky = True
+
+# -- Options for manual page output --------------------------------------------
+
+# authors should be empty and authors should be specified in each man page,
+# because html builder will omit them
+man_pages = [
+    ('qvm-convert-pdf', 'qvm-convert-pdf',
+        'converts potentially untrusted PDFs to a safe-to-view PDF', [], 1),
+    ('qvm-convert-file', 'qvm-convert-file',
+        'converts potentially untrusted files to safe-to-view PDFs', [], 1),
+]

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -72,3 +72,9 @@ man_pages = [
     ('qvm-convert-file', 'qvm-convert-file',
         'converts potentially untrusted files to safe-to-view PDFs', [], 1),
 ]
+
+rst_epilog_lines = []
+for _, name, description, _, _ in man_pages:
+    rst_epilog_lines.append(f'.. |{name}-description| replace:: {description}')
+
+rst_epilog = '\n'.join(rst_epilog_lines)

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -37,19 +37,19 @@ extensions = [
 ]
 
 # -- Extensions configuration ------------------------------------------------
-# Allows references to the docs in dev.qubes-os.org
+# Allows references to the docs in doc.qubes-os.org
 # i.e.: :doc:`core-admin:libvirt`
 intersphinx_mapping = {
-    "qubes-doc": ("https://doc.qubes-os.org/en/latest/", None),
-    "core-admin": ("https://dev.qubes-os.org/projects/core-admin/en/latest/", None),
-    "core-admin-client": (
-        "https://dev.qubes-os.org/projects/core-admin-client/en/latest/",
-        None,
-    ),
-    "core-qrexec": (
-        "https://dev.qubes-os.org/projects/qubes-core-qrexec/en/stable/",
-        None,
-    ),
+    # "qubes-doc": ("https://doc.qubes-os.org/en/latest/", None),
+    # "core-admin": ("https://doc.qubes-os.org/projects/core-admin/en/latest/", None),
+    # "core-admin-client": (
+    #     "https://doc.qubes-os.org/projects/core-admin-client/en/latest/",
+    #     None,
+    # ),
+    # "core-qrexec": (
+    #     "https://doc.qubes-os.org/projects/core-qrexec/en/latest/",
+    #     None,
+    # ),
 }
 
 intersphinx_disabled_reftypes = []

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,0 +1,17 @@
+app-linux-pdf-converter's Qubes documentation
+=============================================
+
+.. toctree::
+   :maxdepth: 1
+
+   qvm-convert-pdf
+   qvm-convert-file
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`
+
+.. vim: ts=3 sw=3 et

--- a/doc/qvm-convert-file.rst
+++ b/doc/qvm-convert-file.rst
@@ -1,14 +1,12 @@
-===================
-QVM-CONVERT-FILE(1)
-===================
+.. program:: qvm-convert-file
 
-NAME
-====
-qvm-convert-file - converts potentially untrusted files to safe-to-view PDFs
+======================================================
+``qvm-convert-file`` -- |qvm-convert-file-description|
+======================================================
 
 SYNOPSIS
 ========
-:command: `qvm-convert-file` [-h] [--batch SIZE] [--archive PATH] [--in-place]
+:command:`qvm-convert-file` [-h] [--batch SIZE] [--archive PATH] [--in-place]
                              [--resolution RESOLUTION] [--password PASSWORD]
                              [--ocr-lang LANGUAGE] [FILES ...]
 

--- a/doc/qvm-convert-pdf.rst
+++ b/doc/qvm-convert-pdf.rst
@@ -1,14 +1,12 @@
-==================
-QVM-CONVERT-PDF(1)
-==================
+.. program:: qvm-convert-pdf
 
-NAME
-====
-qvm-convert-pdf - converts potentially untrusted PDFs to a safe-to-view PDF
+====================================================
+``qvm-convert-pdf`` -- |qvm-convert-pdf-description|
+====================================================
 
 SYNOPSIS
 ========
-:command: `qvm-convert-pdf` [-h] [--batch SIZE] [--archive PATH] [--in-place]
+:command:`qvm-convert-pdf` [-h] [--batch SIZE] [--archive PATH] [--in-place]
                             [--resolution RESOLUTION] [--password PASSWORD]
                             [--ocr-lang LANGUAGE]
 

--- a/rpm_spec/qpdf-converter.spec.in
+++ b/rpm_spec/qpdf-converter.spec.in
@@ -35,7 +35,7 @@ URL:		http://www.qubes-os.org
 
 BuildArch: noarch
 BuildRequires: make
-BuildRequires: pandoc
+BuildRequires: python-sphinx 
 BuildRequires: python%{python3_pkgversion}-setuptools
 BuildRequires: python%{python3_pkgversion}-devel
 %if 0%{?is_opensuse}


### PR DESCRIPTION
* [x] Convert the doc dir into a real sphinx project
* [x] Add .readthedocs.yaml (should it be in `doc/` to keep the root dir tidy?)
* [x] Replace` pandoc by sphinx-build in the build process

Test web build on read the docs: https://parulin-app-linux-pdf-converter.readthedocs.io/en/latest/