### PR TITLE
pdf-converter: add video conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,10 @@ Usage
 
 The generic `qvm-convert-file` command also supports LibreOffice-backed
 document and spreadsheet conversion for DOCX, ODT, XLSX, and ODS files. Those
-formats require LibreOffice to be installed in the relevant template.
+formats require LibreOffice to be installed in the relevant template. It also
+supports common video formats by re-encoding them to `.trusted.ogv` with
+FFmpeg, when FFmpeg is installed in the relevant template. Video data crosses
+the qrexec boundary as raw RGB frames; audio is not preserved.
 
 Authors
 ---------

--- a/archlinux/PKGBUILD.in
+++ b/archlinux/PKGBUILD.in
@@ -17,6 +17,10 @@ depends=(
 )
 optdepends=(
     python-nautilus
+    libreoffice
+    ffmpeg
+    python-pymupdf
+    tesseract-data-eng
 )
 _pkgnvr="${pkgname}-${pkgver}-${pkgrel}"
 source=("${_pkgnvr}.tar.gz")

--- a/debian/control
+++ b/debian/control
@@ -29,6 +29,7 @@ Recommends:
 Suggests:
  python3-nautilus | python-nautilus,
  libreoffice,
+ ffmpeg,
  python3-fitz,
  tesseract-ocr-eng,
 Description: The Qubes service for converting untrusted PDF files into trusted ones

--- a/doc/qvm-convert-file.rst
+++ b/doc/qvm-convert-file.rst
@@ -8,7 +8,7 @@ SYNOPSIS
 ========
 :command:`qvm-convert-file` [-h] [--batch SIZE] [--archive PATH] [--in-place]
                              [--resolution RESOLUTION] [--password PASSWORD]
-                             [--ocr-lang LANGUAGE] [FILES ...]
+                             [--ocr-lang LANGUAGE] [--no-ocr] [FILES ...]
 
 OPTIONS
 ========
@@ -42,12 +42,16 @@ OPTIONS
    Tesseract language code to use for OCR output. Tesseract uses three-letter
    language codes such as ``eng`` for English, not two-letter locale codes.
 
+.. option:: --no-ocr
+
+   Do not use the saved OCR setting for this run.
+
 DESCRIPTION
 ===========
 
 Qubes file converter is a Qubes Application that uses Qubes' flexible qrexec
 (inter-VM communication) infrastructure and Disposable VMs to convert
-potentially untrusted files into safe-to-view PDF files.
+potentially untrusted files into safe-to-view files.
 
 Supported input formats:
 
@@ -62,10 +66,16 @@ Supported input formats:
      - Converted through LibreOffice, then through the PDF rendering pipeline.
    * - XLSX, ODS
      - Converted through LibreOffice, then through the PDF rendering pipeline.
+   * - MP4, OGV, MOV, WEBM, MKV, AVI
+     - Decoded to raw RGB frames, then encoded into an Ogg/Theora video.
 
 For LibreOffice-backed formats, the converter first creates an intermediate PDF
 inside the conversion environment, then uses the same bitmap-based PDF
 conversion pipeline.
+
+For video formats, the converter sends raw RGB frames from the conversion
+environment and writes a ``.trusted.ogv`` file next to the original file. Audio
+is not preserved.
 
 File type detection is performed on the server side. Unsupported file types are
 rejected instead of being converted.
@@ -74,13 +84,18 @@ LibreOffice is optional for PDF conversion, but it is required for the supported
 office document and spreadsheet formats. If LibreOffice is missing, install it
 in the relevant template.
 
+FFmpeg is optional for PDF, document, and spreadsheet conversion, but it is
+required for the supported video formats. If FFmpeg is missing, install it in
+the relevant template.
+
 As with qvm-convert-pdf, the converted PDF may be larger than the original file
 and may lose structural information such as searchable text.
 
 If ``--ocr-lang`` is set, the converter adds a searchable text layer to the
 trusted PDF after the pages have been rendered to safe bitmaps. If
 ``--ocr-lang`` is not set, the command uses the OCR setting saved by
-``qvm-convert-pdf-ocr-settings``.
+``qvm-convert-pdf-ocr-settings``. Use ``--no-ocr`` to ignore the saved OCR
+setting for one command.
 
 OCR is optional. For English OCR, install ``python3-fitz`` and
 ``tesseract-ocr-eng`` on Debian templates, or ``python3-PyMuPDF`` and

--- a/doc/qvm-convert-pdf.rst
+++ b/doc/qvm-convert-pdf.rst
@@ -8,7 +8,7 @@ SYNOPSIS
 ========
 :command:`qvm-convert-pdf` [-h] [--batch SIZE] [--archive PATH] [--in-place]
                             [--resolution RESOLUTION] [--password PASSWORD]
-                            [--ocr-lang LANGUAGE]
+                            [--ocr-lang LANGUAGE] [--no-ocr]
 
 OPTIONS
 =======
@@ -42,6 +42,10 @@ OPTIONS
    Tesseract language code to use for OCR output. Tesseract uses three-letter
    language codes such as ``eng`` for English, not two-letter locale codes.
 
+.. option:: --no-ocr
+
+   Do not use the saved OCR setting for this run.
+
 DESCRIPTION
 ===========
 
@@ -51,8 +55,9 @@ potentially untrusted (e.g. maliciously malformed) PDF files into safe-to-view
 PDF files.
 
 For other supported file types, use ``qvm-convert-file``. It currently handles
-PDF, DOCX, ODT, XLSX, and ODS inputs, with LibreOffice required only for the
-Office document and spreadsheet formats.
+PDF, DOCX, ODT, XLSX, ODS, and common video inputs. LibreOffice is required
+only for the Office document and spreadsheet formats, and FFmpeg is required
+only for video formats.
 
 This is done by having a Disposable VM render each page of a PDF file into a 
 very simple representation (RGB bitmap) that (presumably) leaves no room for 
@@ -79,7 +84,8 @@ template to enable those formats.
 If ``--ocr-lang`` is not set, the command uses the OCR setting saved by
 ``qvm-convert-pdf-ocr-settings``. The graphical file manager action asks for
 this setting the first time it is used, and the settings tool can be launched
-later from the application menu.
+later from the application menu. Use ``--no-ocr`` to ignore the saved OCR
+setting for one command.
 
 AUTHORS
 =======

--- a/qubespdfconverter/client.py
+++ b/qubespdfconverter/client.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python3
 # -*- coding: utf-8 -*-
+# pylint: disable=too-many-lines
 
 # The Qubes OS Project, http://www.qubes-os.org
 #
@@ -37,18 +38,36 @@ from pathlib import Path
 from PIL import Image
 from tempfile import TemporaryDirectory
 
-from qubespdfconverter.constants import LIBREOFFICE_MISSING_EXIT_CODE
+from qubespdfconverter.constants import (
+    FFMPEG_MISSING_EXIT_CODE,
+    LIBREOFFICE_MISSING_EXIT_CODE,
+)
 from qubespdfconverter import ocr, ocr_config
+from qubespdfconverter.protocol import (
+    OutputFileError,
+    PageError,
+    VideoOutput,
+    parse_output_header,
+)
 
 CLIENT_VM_CMD = ["/usr/bin/qrexec-client-vm", "@dispvm", "qubes.PdfConvert"]
 
-MAX_PAGES = 10000
 MAX_IMG_WIDTH = 10000
 MAX_IMG_HEIGHT = 10000
 DEPTH = 8
 RESOLUTION = 300
+STDIN_READ_SIZE = 65536
+VIDEO_OUTPUT_SUFFIX = "ogv"
 
 ERROR_LOGS = asyncio.Queue()
+
+
+def unlink(path):
+    """Wrapper for pathlib.Path.unlink(path, missing_ok=True)"""
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        pass
 
 
 class Status(Enum):
@@ -68,10 +87,6 @@ class ImageDimensions:
 
 class DimensionError(ValueError):
     """Raised if invalid image dimensions were received"""
-
-
-class PageError(ValueError):
-    """Raised if an invalid number of pages was received"""
 
 
 class QrexecError(Exception):
@@ -589,7 +604,7 @@ class Job:
         :param file: Base file
         :param bar: Progress bar
         :param proc: qrexec-client-vm process
-        :param pdf: Path to temporary PDF for appending representations
+        :param output: Path to temporary output file
         """
         self.path = path
         self.password = password
@@ -599,7 +614,7 @@ class Job:
                         position=pos)
         self.base = None
         self.proc = None
-        self.pdf = None
+        self.output = None
 
     async def run(self, archive, depth, in_place):
         self.proc = await asyncio.create_subprocess_exec(
@@ -616,6 +631,7 @@ class Job:
                     PageError,
                     QrexecError,
                     DimensionError,
+                    OutputFileError,
                     RepresentationError,
                     subprocess.CalledProcessError) as e:
                 # Since the qrexec-client-vm subprocesses belong to the same
@@ -639,6 +655,15 @@ class Job:
                         "install libreoffice in the relevant template"
                     )
                     await ERROR_LOGS.put(f"{self.path.name}: {error}")
+                elif (
+                    isinstance(e, subprocess.CalledProcessError)
+                    and e.returncode == FFMPEG_MISSING_EXIT_CODE
+                ):
+                    error = (
+                        "FFmpeg is required for this file type; "
+                        "install ffmpeg in the relevant template"
+                    )
+                    await ERROR_LOGS.put(f"{self.path.name}: {error}")
                 else:
                     await ERROR_LOGS.put(f"{self.path.name}: {e}")
                 if self.proc.returncode is None:
@@ -655,44 +680,58 @@ class Job:
 
     async def _setup(self, tmpdir):
         send_task = asyncio.create_task(self._send())
-        page_task = asyncio.create_task(self._pagenums())
+        header_task = asyncio.create_task(self._output_info())
 
         try:
-            _, pagenums = await asyncio.gather(send_task, page_task)
+            _, output_info = await asyncio.gather(send_task, header_task)
         except QrexecError:
-            await cancel_task(page_task)
+            await cancel_task(header_task)
             raise
+
+        if isinstance(output_info, VideoOutput):
+            self.base = output_info
+            self.bar.reset(total=output_info.frames)
+            self.output = Path(
+                tmpdir,
+                self.path.with_suffix(f".trusted.{VIDEO_OUTPUT_SUFFIX}").name
+            )
+            return
+
+        pagenums = output_info
         try:
             self.bar.reset(total=pagenums)
         except AttributeError:
             self.bar.total = pagenums
             self.bar.refresh()
 
-        self.pdf = Path(tmpdir, self.path.with_suffix(".trusted.pdf").name)
+        self.output = Path(tmpdir, self.path.with_suffix(".trusted.pdf").name)
         self.base = BaseFile(
             self.path,
             pagenums,
-            self.pdf,
+            self.output,
             ocr_lang=self.ocr_lang
         )
 
 
     async def _start(self, archive, depth, in_place):
-        await self.base.sanitize(
-            self.proc,
-            self.bar,
-            depth
-        )
+        if isinstance(self.base, VideoOutput):
+            await self._receive_video_output()
+        else:
+            await self.base.sanitize(
+                self.proc,
+                self.bar,
+                depth
+            )
         await wait_proc(self.proc, CLIENT_VM_CMD)
 
-        if self.password:
+        if self.password and not isinstance(self.base, VideoOutput):
             await self._reencrypt()
 
         await asyncio.get_running_loop().run_in_executor(
             None,
             shutil.move,
-            self.pdf,
-            Path(self.path.parent, self.pdf.name)
+            self.output,
+            Path(self.path.parent, self.output.name)
         )
 
         if in_place:
@@ -713,11 +752,11 @@ class Job:
 
     async def _reencrypt(self):
         """Re-encrypt the trusted PDF with the original password using qpdf"""
-        encrypted = self.pdf.with_suffix(".enc.pdf")
+        encrypted = self.output.with_suffix(".enc.pdf")
         cmd = [
             "qpdf",
             "--encrypt", self.password, self.password, "256", "--",
-            str(self.pdf),
+            str(self.output),
             str(encrypted),
         ]
         proc = await asyncio.create_subprocess_exec(*cmd)
@@ -726,7 +765,7 @@ class Job:
         except subprocess.CalledProcessError as e:
             raise RepresentationError("Failed to re-encrypt PDF") from e
         await asyncio.get_running_loop().run_in_executor(
-            None, encrypted.replace, self.pdf
+            None, encrypted.replace, self.output
         )
 
 
@@ -746,31 +785,126 @@ class Job:
         self.proc.stdin.write_eof()
 
 
-    async def _pagenums(self):
-        """Receive number of pages in original document from server"""
+    async def _output_info(self):
+        """Receive trusted output information from the server."""
         try:
-            untrusted_pagenums = int(await recvline(self.proc))
+            return parse_output_header(await recvline(self.proc))
         except EOFError as e:
             try:
                 await wait_proc(self.proc, CLIENT_VM_CMD)
             except subprocess.CalledProcessError as proc_exc:
                 raise proc_exc from e
-            raise QrexecError("Failed to receive page count") from e
+            raise QrexecError("Failed to receive output information") from e
         except (AttributeError, UnicodeError, ValueError) as e:
             raise QrexecError("Failed to receive page count") from e
-
-        if 1 <= untrusted_pagenums <= MAX_PAGES:
-            pagenums = untrusted_pagenums
-        else:
-            raise PageError("Invalid page count")
-
-        return pagenums
 
 
     def _archive(self, archive):
         """Move original file into an archival directory"""
         Path.mkdir(archive, exist_ok=True)
         self.path.rename(Path(archive, self.path.name))
+
+
+    async def _receive_video_output(self):
+        """Receive raw video frames and encode a trusted video file."""
+        encoder, cmd = await self._start_video_encoder()
+        try:
+            await self._pipe_video_frames(encoder)
+        except (asyncio.CancelledError, QrexecError, RepresentationError):
+            if encoder.stdin is not None and not encoder.stdin.is_closing():
+                encoder.stdin.close()
+            if encoder.returncode is None:
+                await terminate_proc(encoder)
+            raise
+        finally:
+            if encoder.stdin is not None and not encoder.stdin.is_closing():
+                encoder.stdin.close()
+
+        try:
+            await wait_proc(encoder, cmd)
+        except subprocess.CalledProcessError as e:
+            raise RepresentationError("Failed to encode video") from e
+
+        if not self.output.exists():
+            raise RepresentationError("Failed to encode video")
+
+
+    async def _start_video_encoder(self):
+        """Start FFmpeg for writing the trusted video output."""
+        cmd = [
+            "ffmpeg",
+            "-nostdin",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-y",
+            "-f",
+            "rawvideo",
+            "-pix_fmt",
+            self.base.pixel_format,
+            "-s",
+            f"{self.base.width}x{self.base.height}",
+            "-framerate",
+            f"{self.base.fps_num}/{self.base.fps_den}",
+            "-i",
+            "-",
+            "-map_metadata",
+            "-1",
+            "-map_chapters",
+            "-1",
+            "-an",
+            "-sn",
+            "-dn",
+            "-c:v",
+            "libtheora",
+            "-q:v",
+            "10",
+            "-f",
+            "ogg",
+            str(self.output),
+        ]
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdin=asyncio.subprocess.PIPE,
+            )
+        except FileNotFoundError as e:
+            raise subprocess.CalledProcessError(
+                FFMPEG_MISSING_EXIT_CODE,
+                cmd,
+            ) from e
+        return proc, cmd
+
+
+    async def _pipe_video_frames(self, encoder):
+        """Pipe raw frames from qrexec to FFmpeg without buffering all frames."""
+        remaining = self.base.size
+        frame_size = self.base.width * self.base.height * 3
+        completed_frames = 0
+
+        while remaining:
+            read_size = min(STDIN_READ_SIZE, remaining)
+            try:
+                data = await recv_b(self.proc, read_size)
+            except asyncio.IncompleteReadError as e:
+                raise QrexecError("Received inconsistent number of bytes") from e
+
+            try:
+                encoder.stdin.write(data)
+                await encoder.stdin.drain()
+            except (AttributeError, BrokenPipeError, ConnectionResetError) as e:
+                raise RepresentationError("Failed to encode video") from e
+
+            remaining -= len(data)
+            new_completed_frames = (
+                self.base.size - remaining
+            ) // frame_size
+            if new_completed_frames > completed_frames:
+                self.bar.update(new_completed_frames - completed_frames)
+                self.bar.set_status(
+                    f"{new_completed_frames}/{self.base.frames}"
+                )
+                completed_frames = new_completed_frames
 
 
 async def collect_jobs(params):
@@ -813,6 +947,9 @@ async def collect_jobs(params):
 
 def apply_ocr_default(params):
     """Use configured OCR settings if no OCR language was passed."""
+    if params.get("no_ocr") and params.get("ocr_lang") is None:
+        return True
+
     if params.get("ocr_lang") is None:
         params["ocr_lang"] = ocr_config.get_default_ocr_lang()
 
@@ -878,6 +1015,13 @@ async def run(params):
     ):
         return LIBREOFFICE_MISSING_EXIT_CODE
 
+    if any(
+        isinstance(result, subprocess.CalledProcessError)
+        and result.returncode == FFMPEG_MISSING_EXIT_CODE
+        for result in results
+    ):
+        return FFMPEG_MISSING_EXIT_CODE
+
     return int(completed != total)
 
 
@@ -926,6 +1070,11 @@ async def run(params):
     callback=validate_ocr_lang,
     metavar="LANGUAGE",
     help="Tesseract language code for OCR output"
+)
+@click.option(
+    "--no-ocr",
+    is_flag=True,
+    help="Do not use the saved OCR setting for this run"
 )
 @click.argument(
     "files",

--- a/qubespdfconverter/constants.py
+++ b/qubespdfconverter/constants.py
@@ -4,3 +4,4 @@
 """Shared constants for converter clients and server."""
 
 LIBREOFFICE_MISSING_EXIT_CODE = 64
+FFMPEG_MISSING_EXIT_CODE = 65

--- a/qubespdfconverter/file_client.py
+++ b/qubespdfconverter/file_client.py
@@ -57,6 +57,11 @@ from qubespdfconverter import client as pdf_client
     metavar="LANGUAGE",
     help="Tesseract language code for OCR output"
 )
+@click.option(
+    "--no-ocr",
+    is_flag=True,
+    help="Do not use the saved OCR setting for this run"
+)
 @click.argument(
     "files",
     type=Path,

--- a/qubespdfconverter/protocol.py
+++ b/qubespdfconverter/protocol.py
@@ -1,0 +1,95 @@
+#!/usr/bin/python3
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+"""Shared qrexec protocol helpers."""
+
+from dataclasses import dataclass
+
+
+MAX_PAGES = 10000
+MAX_OUTPUT_SIZE = 10 * 1024 * 1024 * 1024
+MAX_VIDEO_RATE_PART = 1000000
+
+
+class OutputFileError(Exception):
+    """Raised if an invalid trusted file header was received."""
+
+
+class PageError(Exception):
+    """Raised if an invalid number of pages was received."""
+
+
+@dataclass(frozen=True)
+class VideoOutput:
+    """Raw video stream metadata received from the server."""
+
+    pixel_format: str
+    width: int
+    height: int
+    fps_num: int
+    fps_den: int
+    frames: int
+    size: int
+
+
+def _parse_video_header(untrusted_header):
+    # pylint: disable=too-many-boolean-expressions
+    try:
+        (
+            _,
+            pixel_format,
+            width,
+            height,
+            fps_num,
+            fps_den,
+            frames,
+            size,
+        ) = untrusted_header.split(" ", 7)
+        width = int(width)
+        height = int(height)
+        fps_num = int(fps_num)
+        fps_den = int(fps_den)
+        frames = int(frames)
+        size = int(size)
+    except ValueError as e:
+        raise OutputFileError("Invalid video output header") from e
+
+    if (
+        pixel_format != "rgb24"
+        or not 1 <= width <= 10000
+        or not 1 <= height <= 10000
+        or not 1 <= fps_num <= MAX_VIDEO_RATE_PART
+        or not 1 <= fps_den <= MAX_VIDEO_RATE_PART
+        or not 1 <= frames <= MAX_PAGES
+    ):
+        raise OutputFileError("Invalid video output header")
+
+    expected_size = width * height * 3 * frames
+    if size != expected_size or not 1 <= size <= MAX_OUTPUT_SIZE:
+        raise OutputFileError("Invalid video output header")
+
+    return VideoOutput(
+        pixel_format,
+        width,
+        height,
+        fps_num,
+        fps_den,
+        frames,
+        size,
+    )
+
+
+def parse_output_header(untrusted_header):
+    """Parse the first server response line."""
+    if untrusted_header.startswith("VIDEO "):
+        return _parse_video_header(untrusted_header)
+
+    try:
+        pagenums = int(untrusted_header)
+    except ValueError as e:
+        raise ValueError("Failed to receive page count") from e
+
+    if 1 <= pagenums <= MAX_PAGES:
+        return pagenums
+
+    raise PageError("Invalid page count")

--- a/qubespdfconverter/server.py
+++ b/qubespdfconverter/server.py
@@ -23,6 +23,7 @@
 import argparse
 import asyncio
 import functools
+import json
 import shutil
 import subprocess
 import sys
@@ -31,7 +32,11 @@ from dataclasses import dataclass
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
-from qubespdfconverter.constants import LIBREOFFICE_MISSING_EXIT_CODE
+from qubespdfconverter.constants import (
+    FFMPEG_MISSING_EXIT_CODE,
+    LIBREOFFICE_MISSING_EXIT_CODE,
+)
+from qubespdfconverter.protocol import VideoOutput
 
 try:
     import magic
@@ -86,6 +91,16 @@ def send_b(data):
     sys.stdout.buffer.flush()
 
 
+def send_file(path):
+    """Send a file to the client without loading it all into memory."""
+    with path.open("rb") as f:
+        while True:
+            data = f.read(STDIN_READ_SIZE)
+            if not data:
+                break
+            send_b(data)
+
+
 def send(data):
     """Qrexec wrapper for sending text data to the client"""
     print(data, flush=True)
@@ -101,6 +116,10 @@ def recv_b():
 
 class LibreOfficeMissingError(ValueError):
     """Raised if LibreOffice is missing in the relevant template."""
+
+
+class FfmpegMissingError(ValueError):
+    """Raised if FFmpeg is missing in the relevant template."""
 
 
 class PdfRenderer:
@@ -204,11 +223,112 @@ class LibreOfficeDocumentRenderer:
         return await self.pdf_renderer().render_page(page, prefix)
 
 
+class VideoRenderer:
+    """Convert videos to raw RGB frames for the trusted client."""
+
+    pixel_format = "rgb24"
+
+    def __init__(self, path, password=b"", resolution=RESOLUTION):
+        self.path = path
+
+    def _probe(self):
+        """Return basic video stream metadata from FFprobe."""
+        cmd = [
+            "ffprobe",
+            "-v",
+            "error",
+            "-select_streams",
+            "v:0",
+            "-show_entries",
+            "stream=width,height,r_frame_rate,avg_frame_rate",
+            "-of",
+            "json",
+            str(self.path),
+        ]
+        try:
+            output = subprocess.run(cmd, capture_output=True, check=True)
+        except FileNotFoundError as exc:
+            raise FfmpegMissingError(
+                "FFmpeg is required for this file type; "
+                "install ffmpeg in the relevant template"
+            ) from exc
+
+        try:
+            stream = json.loads(output.stdout.decode())["streams"][0]
+            width = int(stream["width"])
+            height = int(stream["height"])
+            fps_rate = stream.get("avg_frame_rate") or stream["r_frame_rate"]
+            fps_num, fps_den = map(int, fps_rate.split("/", 1))
+            if not fps_num:
+                fps_num, fps_den = map(int, stream["r_frame_rate"].split("/", 1))
+        except (KeyError, IndexError, TypeError, ValueError) as exc:
+            raise ValueError("failed to read video metadata") from exc
+
+        if not width or not height or not fps_num or not fps_den:
+            raise ValueError("invalid video metadata")
+
+        return width, height, fps_num, fps_den
+
+    def convert(self, output):
+        """Decode the video stream to raw RGB frames."""
+        width, height, fps_num, fps_den = self._probe()
+        cmd = [
+            "ffmpeg",
+            "-nostdin",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-y",
+            "-i",
+            str(self.path),
+            "-map",
+            "0:v:0",
+            "-map_metadata",
+            "-1",
+            "-map_chapters",
+            "-1",
+            "-an",
+            "-sn",
+            "-dn",
+            "-pix_fmt",
+            self.pixel_format,
+            "-f",
+            "rawvideo",
+            str(output),
+        ]
+        try:
+            subprocess.run(cmd, capture_output=True, check=True)
+        except FileNotFoundError as exc:
+            raise FfmpegMissingError(
+                "FFmpeg is required for this file type; "
+                "install ffmpeg in the relevant template"
+            ) from exc
+
+        if not output.exists():
+            raise ValueError("video conversion did not produce an output file")
+
+        size = output.stat().st_size
+        frame_size = width * height * 3
+        if not size or size % frame_size:
+            raise ValueError("video conversion produced invalid raw frame data")
+
+        return VideoOutput(
+            self.pixel_format,
+            width,
+            height,
+            fps_num,
+            fps_den,
+            size // frame_size,
+            size,
+        )
+
+
 RENDERERS = {
     "docx": functools.partial(LibreOfficeDocumentRenderer, suffix=".docx"),
     "ods": functools.partial(LibreOfficeDocumentRenderer, suffix=".ods"),
     "odt": functools.partial(LibreOfficeDocumentRenderer, suffix=".odt"),
     "pdf": PdfRenderer,
+    "video": VideoRenderer,
     "xlsx": functools.partial(LibreOfficeDocumentRenderer, suffix=".xlsx"),
 }
 
@@ -218,6 +338,12 @@ MIME_DISPATCH = {
     "application/vnd.oasis.opendocument.spreadsheet": "ods",
     "application/vnd.oasis.opendocument.text": "odt",
     "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": "xlsx",
+    "video/mp4": "video",
+    "video/ogg": "video",
+    "video/quicktime": "video",
+    "video/webm": "video",
+    "video/x-matroska": "video",
+    "video/x-msvideo": "video",
 }
 
 
@@ -384,6 +510,27 @@ class BaseFile:
             self.batch.task_done()
 
 
+class VideoFile:
+    """Unsanitized video converted to raw frames."""
+
+    def __init__(self, path, renderer):
+        self.path = path
+        self.renderer = renderer
+
+    def sanitize(self):
+        """Convert and send raw video frames to the client."""
+        output = self.path.with_suffix(".rgb")
+        info = self.renderer.convert(output)
+        send(
+            "VIDEO "
+            f"{info.pixel_format} "
+            f"{info.width} {info.height} "
+            f"{info.fps_num} {info.fps_den} "
+            f"{info.frames} {info.size}"
+        )
+        send_file(output)
+
+
 parser = argparse.ArgumentParser(
     prog="qubes.PdfConvert",
     description="Server side of qvm-convert-pdf",
@@ -425,16 +572,24 @@ def main():
         pdf_path.write_bytes(data)
 
         try:
+            renderer_name = renderer_name_for_path(pdf_path)
             renderer = create_renderer(
-                renderer_name_for_path(pdf_path),
+                renderer_name,
                 pdf_path,
                 password,
                 args.resolution,
             )
-            base = BaseFile(pdf_path, renderer)
-            asyncio.run(base.sanitize())
+            if isinstance(renderer, VideoRenderer):
+                base = VideoFile(pdf_path, renderer)
+                base.sanitize()
+            else:
+                base = BaseFile(pdf_path, renderer)
+                asyncio.run(base.sanitize())
         except subprocess.CalledProcessError:
             sys.exit(1)
+        except FfmpegMissingError as exc:
+            print(f"error: {exc}", file=sys.stderr, flush=True)
+            sys.exit(FFMPEG_MISSING_EXIT_CODE)
         except LibreOfficeMissingError as exc:
             print(f"error: {exc}", file=sys.stderr, flush=True)
             sys.exit(LIBREOFFICE_MISSING_EXIT_CODE)

--- a/qubespdfconverter/tests/integ.py
+++ b/qubespdfconverter/tests/integ.py
@@ -281,6 +281,32 @@ with zipfile.ZipFile(filename, "w") as ods:
         if p.returncode != 0:
             self.skipTest('failed to create test ods: {}'.format(stdout))
 
+    def create_video(self, filename):
+        '''Create a tiny video file from generated frames
+
+        :param filename: output filename
+        '''
+        for frame_no in range(3):
+            p = self.vm.run(
+                'cat > /tmp/video-frame{no:04}.svg && '
+                'gm convert /tmp/video-frame{no:04}.svg '
+                '/tmp/video-frame{no:04}.png 2>&1'.format(no=frame_no),
+                passio_popen=True)
+            (stdout, _) = p.communicate(self.circle_svg.format(
+                text='Frame {}'.format(frame_no + 1)).encode())
+            if p.returncode != 0:
+                self.skipTest(
+                    'failed to create test video frame: {}'.format(stdout))
+
+        p = self.vm.run(
+            'ffmpeg -nostdin -hide_banner -loglevel error -y '
+            '-framerate 1 -i /tmp/video-frame%04d.png -frames:v 3 '
+            '-pix_fmt yuv420p -c:v mpeg4 "{}" 2>&1'.format(filename),
+            passio_popen=True)
+        (stdout, _) = p.communicate()
+        if p.returncode != 0:
+            self.skipTest('failed to create test video: {}'.format(stdout))
+
     def get_pdfinfo(self, filename):
         p = self.vm.run('pdfinfo "{}"'.format(filename), passio_popen=True)
         (stdout, _) = p.communicate()
@@ -453,6 +479,24 @@ with zipfile.ZipFile(filename, "w") as ods:
             self.vm.run('test -r "QubesUntrustedPDFs/test.ods"', wait=True), 0)
         self.assertEqual(self.vm.run(
             'diff "orig.ods" "QubesUntrustedPDFs/test.ods"', wait=True), 0)
+
+    def test_009_video(self):
+        if self.vm.run('command -v ffmpeg >/dev/null', wait=True) != 0:
+            self.skipTest('ffmpeg not installed')
+        self.create_video('test.mp4')
+        p = self.vm.run(
+            'cp test.mp4 orig.mp4; qvm-convert-file test.mp4 2>&1',
+            passio_popen=True)
+        (stdout, _) = p.communicate()
+        self.assertEqual(
+            p.returncode, 0, 'qvm-convert-file failed: {}'.format(stdout))
+        self.assertEqual(
+            self.vm.run('test -r "test.trusted.ogv"', wait=True), 0)
+
+        self.assertEqual(
+            self.vm.run('test -r "QubesUntrustedPDFs/test.mp4"', wait=True), 0)
+        self.assertEqual(self.vm.run(
+            'diff "orig.mp4" "QubesUntrustedPDFs/test.mp4"', wait=True), 0)
 
 
 def list_tests():

--- a/qubespdfconverter/tests/test_client.py
+++ b/qubespdfconverter/tests/test_client.py
@@ -11,14 +11,18 @@ from unittest import mock
 
 import click
 
-from qubespdfconverter.constants import LIBREOFFICE_MISSING_EXIT_CODE
+from qubespdfconverter.constants import (
+    FFMPEG_MISSING_EXIT_CODE,
+    LIBREOFFICE_MISSING_EXIT_CODE,
+)
 from qubespdfconverter import ocr_config
 
 from qubespdfconverter.client import (
     BadPath,
     BaseFile,
+    ERROR_LOGS,
     Job,
-    PageError,
+    QrexecError,
     apply_ocr_default,
     expand_dir,
     run,
@@ -26,6 +30,12 @@ from qubespdfconverter.client import (
     validate_paths,
 )
 from qubespdfconverter.ocr import OcrDependencyError
+from qubespdfconverter.protocol import (
+    OutputFileError,
+    PageError,
+    VideoOutput,
+    parse_output_header,
+)
 
 
 class DummyProc:
@@ -94,7 +104,7 @@ class TC_ClientCancel(unittest.IsolatedAsyncioTestCase):
         handled = {call.args[0] for call in add_handler_mock.mock_calls}
         self.assertEqual(handled, {signal.SIGINT, signal.SIGTERM})
 
-    async def test_003_pagenums_propagates_missing_libreoffice_exit_code(self):
+    async def test_003_output_info_propagates_missing_libreoffice_exit_code(self):
         job = Job(Path("/tmp/test.docx"), 0)
         proc = DummyProc()
         proc.returncode = LIBREOFFICE_MISSING_EXIT_CODE
@@ -102,7 +112,7 @@ class TC_ClientCancel(unittest.IsolatedAsyncioTestCase):
         job.proc = proc
 
         with self.assertRaises(subprocess.CalledProcessError) as exc:
-            await job._pagenums()
+            await job._output_info()
 
         self.assertEqual(exc.exception.returncode, LIBREOFFICE_MISSING_EXIT_CODE)
 
@@ -160,6 +170,189 @@ class TC_ClientCancel(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(result)
         self.assertEqual(params["ocr_lang"], "eng")
         check_mock.assert_called_once_with("eng")
+
+    async def test_006_no_ocr_skips_configured_ocr_default(self):
+        params = {"ocr_lang": None, "no_ocr": True}
+
+        with mock.patch(
+            "qubespdfconverter.client.ocr_config.get_default_ocr_lang",
+            return_value="eng",
+        ) as default_mock, mock.patch(
+            "qubespdfconverter.client.ocr.check_available"
+        ) as check_mock:
+            result = apply_ocr_default(params)
+
+        self.assertTrue(result)
+        self.assertIsNone(params["ocr_lang"])
+        default_mock.assert_not_called()
+        check_mock.assert_not_called()
+
+    async def test_007_ffmpeg_error_logs_fixed_message(self):
+        while not ERROR_LOGS.empty():
+            ERROR_LOGS.get_nowait()
+            ERROR_LOGS.task_done()
+
+        job = Job(Path("/tmp/test.mp4"), 0)
+        proc = DummyProc()
+
+        with mock.patch(
+            "asyncio.create_subprocess_exec", new=mock.AsyncMock(return_value=proc)
+        ):
+            job._setup = mock.AsyncMock(
+                side_effect=subprocess.CalledProcessError(
+                    FFMPEG_MISSING_EXIT_CODE,
+                    "qrexec-client-vm",
+                )
+            )
+
+            with self.assertRaises(subprocess.CalledProcessError):
+                await job.run(Path("/tmp/archive"), depth=1, in_place=False)
+
+        self.assertTrue(proc.terminated)
+        error = await ERROR_LOGS.get()
+        ERROR_LOGS.task_done()
+        self.assertIn("FFmpeg is required for this file type", error)
+        self.assertIn("relevant template", error)
+
+    async def test_008_setup_accepts_video_output_header(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            job = Job(Path(tmpdir, "source.mp4"), 0)
+            job.bar = mock.Mock()
+            job._send = mock.AsyncMock()
+            output = VideoOutput("rgb24", 2, 2, 1, 1, 3, 36)
+            job._output_info = mock.AsyncMock(return_value=output)
+
+            await job._setup(tmpdir)
+
+        self.assertEqual(job.base, output)
+        self.assertEqual(job.output.name, "source.trusted.ogv")
+        job.bar.reset.assert_called_once_with(total=3)
+
+    async def test_009_receive_video_output_encodes_file(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            job = Job(Path(tmpdir, "source.mp4"), 0)
+            job.base = VideoOutput("rgb24", 1, 1, 1, 1, 1, 3)
+            job.proc = mock.Mock()
+            job.output = Path(tmpdir, "source.trusted.ogv")
+            job.bar = mock.Mock()
+            writer = mock.Mock()
+            writer.is_closing.return_value = False
+            writer.drain = mock.AsyncMock()
+            encoder = mock.Mock()
+            encoder.stdin = writer
+            encoder.returncode = None
+            encoder.wait = mock.AsyncMock(return_value=0)
+            encoder.wait.side_effect = lambda: setattr(encoder, "returncode", 0)
+            job._start_video_encoder = mock.AsyncMock(
+                return_value=(encoder, ["ffmpeg"])
+            )
+            job.output.write_bytes(b"ogv")
+
+            with mock.patch(
+                "qubespdfconverter.client.recv_b",
+                new=mock.AsyncMock(return_value=b"rgb"),
+            ) as recv_mock:
+                await job._receive_video_output()
+
+            recv_mock.assert_awaited_once_with(job.proc, 3)
+            writer.write.assert_called_once_with(b"rgb")
+            writer.drain.assert_awaited_once()
+            writer.close.assert_called_once()
+            self.assertFalse(Path(tmpdir, "source.trusted.rgb").exists())
+            job.bar.update.assert_called_once_with(1)
+            job.bar.set_status.assert_called_once_with("1/1")
+
+    async def test_010_receive_video_output_rejects_short_read(self):
+        job = Job(Path("/tmp/source.mp4"), 0)
+        job.base = VideoOutput("rgb24", 1, 1, 1, 1, 1, 3)
+        job.proc = mock.Mock()
+        job.output = Path("/tmp/source.trusted.ogv")
+        writer = mock.Mock()
+        writer.is_closing.return_value = False
+        encoder = DummyProc()
+        encoder.stdin = writer
+        job._start_video_encoder = mock.AsyncMock(
+            return_value=(encoder, ["ffmpeg"])
+        )
+
+        with mock.patch(
+            "qubespdfconverter.client.recv_b",
+            new=mock.AsyncMock(
+                side_effect=asyncio.IncompleteReadError(b"o", 3)
+            ),
+        ):
+            with self.assertRaises(QrexecError):
+                await job._receive_video_output()
+
+        self.assertTrue(encoder.terminated)
+
+    async def test_011_start_video_encoder_uses_raw_input_metadata(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            job = Job(Path(tmpdir, "source.mp4"), 0)
+            job.base = VideoOutput("rgb24", 2, 3, 1, 1, 1, 18)
+            job.output = Path(tmpdir, "source.trusted.ogv")
+            proc = DummyProc()
+            proc.returncode = 0
+
+            with mock.patch(
+                "asyncio.create_subprocess_exec",
+                new=mock.AsyncMock(return_value=proc),
+            ) as exec_mock:
+                await job._start_video_encoder()
+
+        cmd = exec_mock.call_args[0]
+        self.assertIn("rawvideo", cmd)
+        self.assertIn("rgb24", cmd)
+        self.assertIn("2x3", cmd)
+        self.assertEqual(cmd[cmd.index("-i") + 1], "-")
+        self.assertIn("libtheora", cmd)
+        self.assertEqual(cmd[cmd.index("-q:v") + 1], "10")
+
+    async def test_012_start_video_encoder_reports_missing_ffmpeg(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            job = Job(Path(tmpdir, "source.mp4"), 0)
+            job.base = VideoOutput("rgb24", 1, 1, 1, 1, 1, 3)
+            job.output = Path(tmpdir, "source.trusted.ogv")
+
+            with mock.patch(
+                "asyncio.create_subprocess_exec",
+                side_effect=FileNotFoundError,
+            ):
+                with self.assertRaises(subprocess.CalledProcessError) as exc:
+                    await job._start_video_encoder()
+
+        self.assertEqual(exc.exception.returncode, FFMPEG_MISSING_EXIT_CODE)
+
+    async def test_013_run_propagates_missing_ffmpeg_exit_code(self):
+        loop = asyncio.get_running_loop()
+
+        async def failed_task():
+            raise subprocess.CalledProcessError(
+                FFMPEG_MISSING_EXIT_CODE,
+                "qrexec-client-vm",
+            )
+
+        with mock.patch(
+            "qubespdfconverter.client.collect_jobs",
+            new=mock.AsyncMock(
+                return_value=([], [asyncio.create_task(failed_task())], 0)
+            ),
+        ), mock.patch(
+            "qubespdfconverter.client.apply_ocr_default",
+            return_value=True,
+        ), mock.patch.object(loop, "add_signal_handler"):
+            result = await run(
+                {
+                    "resolution": 300,
+                    "files": [Path("/tmp/test.mp4")],
+                    "archive": Path("/tmp/archive"),
+                    "batch": 1,
+                    "in_place": False,
+                    "ocr_lang": None,
+                }
+            )
+
+        self.assertEqual(result, FFMPEG_MISSING_EXIT_CODE)
 
 
 class TC_ExpandDir(unittest.TestCase):
@@ -261,6 +454,39 @@ class TC_ValidatePaths(unittest.TestCase):
         b = self._touch("b.pdf")
         result = validate_paths(None, None, [a, b])
         self.assertEqual(set(result), {a.resolve(), b.resolve()})
+
+
+class TC_OutputHeader(unittest.TestCase):
+    def test_000_parse_page_count_header(self):
+        self.assertEqual(parse_output_header("3"), 3)
+
+    def test_001_parse_video_header(self):
+        output = parse_output_header("VIDEO rgb24 2 2 1 1 3 36")
+
+        self.assertEqual(output, VideoOutput("rgb24", 2, 2, 1, 1, 3, 36))
+
+    def test_002_reject_invalid_video_pixel_format(self):
+        with self.assertRaises(OutputFileError):
+            parse_output_header("VIDEO yuv420p 2 2 1 1 3 36")
+
+    def test_003_reject_invalid_video_size(self):
+        with self.assertRaises(OutputFileError):
+            parse_output_header("VIDEO rgb24 2 2 1 1 3 35")
+
+    def test_004_reject_malformed_video_header(self):
+        with self.assertRaises(OutputFileError):
+            parse_output_header("VIDEO rgb24 2 2")
+
+    def test_005_reject_invalid_page_count(self):
+        with self.assertRaises(PageError):
+            parse_output_header("0")
+
+    def test_006_reject_nonnumeric_page_count(self):
+        with self.assertRaises(ValueError):
+            parse_output_header("not-a-page-count")
+
+    def test_007_ffmpeg_exit_code_is_nonzero(self):
+        self.assertGreater(FFMPEG_MISSING_EXIT_CODE, 0)
 
 
 class TC_OcrLang(unittest.TestCase):

--- a/qubespdfconverter/tests/test_file_client.py
+++ b/qubespdfconverter/tests/test_file_client.py
@@ -77,6 +77,25 @@ class TC_FileClient(unittest.TestCase):
         params = run_mock.await_args.args[0]
         self.assertEqual(params["ocr_lang"], "eng")
 
+    def test_no_ocr_is_forwarded(self):
+        runner = CliRunner()
+
+        with runner.isolated_filesystem():
+            Path("report.pdf").write_bytes(b"%PDF-1.7\n")
+
+            with mock.patch(
+                "qubespdfconverter.file_client.pdf_client.run",
+                new=mock.AsyncMock(return_value=False),
+            ) as run_mock:
+                result = runner.invoke(
+                    file_client.main,
+                    ["--no-ocr", "report.pdf"]
+                )
+
+        self.assertEqual(result.exit_code, 0)
+        params = run_mock.await_args.args[0]
+        self.assertTrue(params["no_ocr"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/qubespdfconverter/tests/test_password.py
+++ b/qubespdfconverter/tests/test_password.py
@@ -15,8 +15,11 @@ from qubespdfconverter.constants import LIBREOFFICE_MISSING_EXIT_CODE
 
 from qubespdfconverter.server import (
     BaseFile,
+    FfmpegMissingError,
     LibreOfficeDocumentRenderer,
     PdfRenderer,
+    VideoFile,
+    VideoRenderer,
     create_renderer,
     LibreOfficeMissingError,
     renderer_name_for_path,
@@ -150,6 +153,13 @@ class TC_ServerPassword(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(renderer.resolution, 200)
         self.assertEqual(renderer.suffix, ".xlsx")
 
+    def test_create_renderer_returns_video_renderer(self):
+        """The server dispatch table creates the video renderer."""
+        with tempfile.NamedTemporaryFile(suffix=".mp4") as f:
+            renderer = create_renderer("video", Path(f.name))
+
+        self.assertIsInstance(renderer, VideoRenderer)
+
     def test_create_renderer_rejects_unknown_type(self):
         """Unknown renderer names fail before any conversion starts."""
         with tempfile.NamedTemporaryFile(suffix=".pdf") as f:
@@ -217,6 +227,16 @@ class TC_ServerPassword(unittest.IsolatedAsyncioTestCase):
             renderer_name = renderer_name_for_path(Path(f.name))
 
         self.assertEqual(renderer_name, "xlsx")
+
+    def test_server_dispatches_mp4_mime_to_video_renderer_name(self):
+        """MP4 MIME detection selects the video renderer."""
+        with tempfile.NamedTemporaryFile(suffix=".mp4") as f, mock.patch(
+            "qubespdfconverter.server.detect_mime",
+            return_value="video/mp4",
+        ):
+            renderer_name = renderer_name_for_path(Path(f.name))
+
+        self.assertEqual(renderer_name, "video")
 
     def test_server_rejects_unsupported_mime(self):
         """Unsupported MIME types fail before selecting a renderer."""
@@ -294,6 +314,132 @@ class TC_ServerPassword(unittest.IsolatedAsyncioTestCase):
 
             with mock.patch("subprocess.run", side_effect=fake_run):
                 self.assertEqual(renderer.page_count(), 2)
+
+    def test_video_renderer_converts_with_ffmpeg(self):
+        """Video rendering decodes to raw RGB frames with FFmpeg."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir, "source.mp4")
+            output = Path(tmpdir, "trusted.rgb")
+            path.write_bytes(b"video")
+            renderer = VideoRenderer(path)
+
+            def fake_run(cmd, capture_output, check):
+                if cmd[0] == "ffprobe":
+                    return mock.Mock(
+                        stdout=(
+                            b'{"streams":[{"width":2,"height":2,'
+                            b'"r_frame_rate":"1/1"}]}'
+                        )
+                    )
+
+                self.assertEqual(cmd[0], "ffmpeg")
+                self.assertIn("-map_metadata", cmd)
+                self.assertIn("-1", cmd)
+                self.assertIn("rawvideo", cmd)
+                self.assertIn("rgb24", cmd)
+                self.assertNotIn("libtheora", cmd)
+                output.write_bytes(b"\x00" * 12)
+                return mock.Mock(stdout=b"")
+
+            with mock.patch("subprocess.run", side_effect=fake_run):
+                info = renderer.convert(output)
+
+            self.assertEqual(info.width, 2)
+            self.assertEqual(info.height, 2)
+            self.assertEqual(info.frames, 1)
+            self.assertEqual(output.read_bytes(), b"\x00" * 12)
+
+    def test_video_renderer_prefers_average_frame_rate(self):
+        """Video rendering uses average frame rate metadata when available."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir, "source.mp4")
+            output = Path(tmpdir, "trusted.rgb")
+            path.write_bytes(b"video")
+            renderer = VideoRenderer(path)
+
+            def fake_run(cmd, capture_output, check):
+                if cmd[0] == "ffprobe":
+                    return mock.Mock(
+                        stdout=(
+                            b'{"streams":[{"width":2,"height":2,'
+                            b'"r_frame_rate":"60/1",'
+                            b'"avg_frame_rate":"30/1"}]}'
+                        )
+                    )
+
+                output.write_bytes(b"\x00" * 24)
+                return mock.Mock(stdout=b"")
+
+            with mock.patch("subprocess.run", side_effect=fake_run):
+                info = renderer.convert(output)
+
+            self.assertEqual(info.fps_num, 30)
+            self.assertEqual(info.fps_den, 1)
+            self.assertEqual(info.frames, 2)
+
+    def test_video_renderer_reports_missing_ffmpeg(self):
+        """Missing FFmpeg is reported as a clear conversion error."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir, "source.mp4")
+            path.write_bytes(b"video")
+            renderer = VideoRenderer(path)
+
+            with mock.patch("subprocess.run", side_effect=FileNotFoundError):
+                with self.assertRaisesRegex(FfmpegMissingError, "relevant template"):
+                    renderer.convert(Path(tmpdir, "trusted.rgb"))
+
+    def test_video_renderer_reports_missing_output(self):
+        """A failed video conversion without output is reported clearly."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir, "source.mp4")
+            output = Path(tmpdir, "trusted.rgb")
+            path.write_bytes(b"video")
+            renderer = VideoRenderer(path)
+
+            def fake_run(cmd, capture_output, check):
+                if cmd[0] == "ffprobe":
+                    return mock.Mock(
+                        stdout=(
+                            b'{"streams":[{"width":2,"height":2,'
+                            b'"r_frame_rate":"1/1"}]}'
+                        )
+                    )
+                return mock.Mock()
+
+            with mock.patch("subprocess.run", side_effect=fake_run):
+                with self.assertRaisesRegex(ValueError, "did not produce"):
+                    renderer.convert(output)
+
+    def test_video_file_sends_raw_output(self):
+        """VideoFile sends a raw video header and frame bytes."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir, "source.mp4")
+            path.write_bytes(b"video")
+            renderer = mock.Mock()
+
+            def convert(output):
+                output.write_bytes(b"\x00" * 12)
+                return mock.Mock(
+                    pixel_format="rgb24",
+                    width=2,
+                    height=2,
+                    fps_num=1,
+                    fps_den=1,
+                    frames=1,
+                    size=12,
+                )
+
+            renderer.convert.side_effect = convert
+            video = VideoFile(path, renderer)
+
+            with mock.patch("qubespdfconverter.server.send") as send_mock, mock.patch(
+                "qubespdfconverter.server.send_b"
+            ) as send_b_mock:
+                video.sanitize()
+
+        renderer.convert.assert_called_once()
+        send_mock.assert_called_once_with("VIDEO rgb24 2 2 1 1 1 12")
+        send_b_mock.assert_called_once_with(b"\x00" * 12)
 
     def test_ods_renderer_uses_ods_extension_for_libreoffice(self):
         """ODS rendering uses the same LibreOffice path with an ODS input."""

--- a/qvm-convert-file-pcmanfm-qt.desktop
+++ b/qvm-convert-file-pcmanfm-qt.desktop
@@ -5,5 +5,5 @@ Icon=gtk-convert
 Profiles=on_supported_file;
 
 [X-Action-Profile on_supported_file]
-MimeTypes=application/vnd.openxmlformats-officedocument.wordprocessingml.document;application/vnd.oasis.opendocument.text;application/vnd.openxmlformats-officedocument.spreadsheetml.sheet;application/vnd.oasis.opendocument.spreadsheet;
+MimeTypes=application/vnd.openxmlformats-officedocument.wordprocessingml.document;application/vnd.oasis.opendocument.text;application/vnd.openxmlformats-officedocument.spreadsheetml.sheet;application/vnd.oasis.opendocument.spreadsheet;video/mp4;video/ogg;video/quicktime;video/webm;video/x-matroska;video/x-msvideo;
 Exec=/usr/lib/qubes/qvm-convert-pdf.gnome --file %F

--- a/qvm-convert-file.desktop
+++ b/qvm-convert-file.desktop
@@ -2,7 +2,7 @@
 Actions=QvmConvertFile;
 Type=Service
 X-KDE-ServiceTypes=KonqPopupMenu/Plugin
-MimeType=application/vnd.openxmlformats-officedocument.wordprocessingml.document;application/vnd.oasis.opendocument.text;application/vnd.openxmlformats-officedocument.spreadsheetml.sheet;application/vnd.oasis.opendocument.spreadsheet;
+MimeType=application/vnd.openxmlformats-officedocument.wordprocessingml.document;application/vnd.oasis.opendocument.text;application/vnd.openxmlformats-officedocument.spreadsheetml.sheet;application/vnd.oasis.opendocument.spreadsheet;video/mp4;video/ogg;video/quicktime;video/webm;video/x-matroska;video/x-msvideo;
 
 [Desktop Action QvmConvertFile]
 Exec=/usr/lib/qubes/qvm-convert-pdf.gnome --file %U

--- a/qvm-convert-pdf.gnome
+++ b/qvm-convert-pdf.gnome
@@ -23,6 +23,7 @@
 set -u
 
 LIBREOFFICE_MISSING_EXIT_CODE=64
+FFMPEG_MISSING_EXIT_CODE=65
 
 backend="--pdf"
 if [ "${1:-}" = "--pdf" ] || [ "${1:-}" = "--file" ]; then
@@ -75,6 +76,9 @@ converter_rc="$?"
 
 if [ "$converter_rc" -eq "$LIBREOFFICE_MISSING_EXIT_CODE" ]; then
     zenity --error --text="LibreOffice is required for this file type. Install libreoffice in the relevant template."
+fi
+if [ "$converter_rc" -eq "$FFMPEG_MISSING_EXIT_CODE" ]; then
+    zenity --error --text="FFmpeg is required for this file type. Install ffmpeg in the relevant template."
 fi
 
 exit "$converter_rc"

--- a/qvm_convert_pdf_nautilus.py
+++ b/qvm_convert_pdf_nautilus.py
@@ -3,7 +3,19 @@ import os
 from gi.repository import Nautilus, GObject, GLib
 
 
-SUPPORTED_EXTENSIONS = ('.pdf', '.docx', '.odt', '.xlsx', '.ods')
+SUPPORTED_EXTENSIONS = (
+    '.pdf',
+    '.docx',
+    '.odt',
+    '.xlsx',
+    '.ods',
+    '.avi',
+    '.mkv',
+    '.mov',
+    '.mp4',
+    '.ogv',
+    '.webm',
+)
 
 
 class ConvertPdfItemExtension(GObject.GObject, Nautilus.MenuProvider):

--- a/rpm_spec/qpdf-converter.spec.in
+++ b/rpm_spec/qpdf-converter.spec.in
@@ -57,6 +57,7 @@ Requires:	python%{python3_pkgversion}-magic
 Requires:	python%{python3_pkgversion}-tqdm
 Recommends:	zenity
 Suggests:	libreoffice
+Suggests:	ffmpeg
 Suggests:	python%{python3_pkgversion}-PyMuPDF
 Suggests:	tesseract-langpack-eng
 


### PR DESCRIPTION
This is the cleaned-up video conversion PR after the review on #57.

It adds initial support for common video inputs. The VM side decodes video to raw RGB frames and sends those frames in chunks. The client side writes the final `.trusted.ogv` file, so the handoff stays simpler and does not keep the full raw stream in memory.

Audio is left out for now to keep this first version small.

Validation:
- `python -m py_compile qubespdfconverter\protocol.py qubespdfconverter\server.py qubespdfconverter\client.py qubespdfconverter\tests\test_client.py qubespdfconverter\tests\test_password.py`
- `PYTHONPATH=. python qubespdfconverter\tests\test_client.py TC_ClientCancel.test_008_setup_accepts_video_output_header TC_ClientCancel.test_009_receive_video_output_encodes_file TC_ClientCancel.test_010_receive_video_output_rejects_short_read TC_ClientCancel.test_011_start_video_encoder_uses_raw_input_metadata TC_ClientCancel.test_012_start_video_encoder_reports_missing_ffmpeg TC_OutputHeader`
- `PYTHONPATH=. python qubespdfconverter\tests\test_password.py`
- `python -m pylint --rcfile=.pylintrc qubespdfconverter\protocol.py qubespdfconverter\server.py qubespdfconverter\client.py`
- `git diff --check`
