### PR TITLE
pdf-converter: add PPTX presentation conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,12 @@ Usage
     Total Sanitized Files: 2/3
 
 The generic `qvm-convert-file` command also supports LibreOffice-backed
-document and spreadsheet conversion for DOCX, ODT, XLSX, and ODS files. Those
-formats require LibreOffice to be installed in the relevant template. It also
-supports common video formats by re-encoding them to `.trusted.ogv` with
-FFmpeg, when FFmpeg is installed in the relevant template. Video data crosses
-the qrexec boundary as raw RGB frames; audio is not preserved.
+document, spreadsheet, and presentation conversion for DOCX, ODT, XLSX, ODS,
+and PPTX files. Those formats require LibreOffice to be installed in the
+relevant template. It also supports common video formats by re-encoding them
+to `.trusted.ogv` with FFmpeg, when FFmpeg is installed in the relevant
+template. Video data crosses the qrexec boundary as raw RGB frames; audio is
+not preserved.
 
 Authors
 ---------

--- a/qubespdfconverter/server.py
+++ b/qubespdfconverter/server.py
@@ -328,6 +328,7 @@ RENDERERS = {
     "ods": functools.partial(LibreOfficeDocumentRenderer, suffix=".ods"),
     "odt": functools.partial(LibreOfficeDocumentRenderer, suffix=".odt"),
     "pdf": PdfRenderer,
+    "pptx": functools.partial(LibreOfficeDocumentRenderer, suffix=".pptx"),
     "video": VideoRenderer,
     "xlsx": functools.partial(LibreOfficeDocumentRenderer, suffix=".xlsx"),
 }
@@ -337,6 +338,9 @@ MIME_DISPATCH = {
     "application/vnd.openxmlformats-officedocument.wordprocessingml.document": ("docx"),
     "application/vnd.oasis.opendocument.spreadsheet": "ods",
     "application/vnd.oasis.opendocument.text": "odt",
+    "application/vnd.openxmlformats-officedocument.presentationml.presentation": (
+        "pptx"
+    ),
     "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": "xlsx",
     "video/mp4": "video",
     "video/ogg": "video",

--- a/qubespdfconverter/tests/integ.py
+++ b/qubespdfconverter/tests/integ.py
@@ -281,6 +281,43 @@ with zipfile.ZipFile(filename, "w") as ods:
         if p.returncode != 0:
             self.skipTest('failed to create test ods: {}'.format(stdout))
 
+    def create_pptx(self, filename, text):
+        '''Create PPTX file with given (textual) content
+
+        :param filename: output filename
+        :param text: text to be placed in the presentation
+        '''
+        source = filename.rsplit('.', 1)[0] + '.fodp'
+        presentation = '''<?xml version="1.0" encoding="UTF-8"?>
+<office:document
+  xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0"
+  xmlns:draw="urn:oasis:names:tc:opendocument:xmlns:drawing:1.0"
+  xmlns:presentation="urn:oasis:names:tc:opendocument:xmlns:presentation:1.0"
+  xmlns:svg="urn:oasis:names:tc:opendocument:xmlns:svg-compatible:1.0"
+  xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0"
+  office:mimetype="application/vnd.oasis.opendocument.presentation"
+  office:version="1.2">
+  <office:body>
+    <office:presentation>
+      <draw:page draw:name="page1">
+        <draw:frame presentation:class="title"
+          svg:x="1cm" svg:y="1cm" svg:width="20cm" svg:height="3cm">
+          <draw:text-box><text:p>{}</text:p></draw:text-box>
+        </draw:frame>
+      </draw:page>
+    </office:presentation>
+  </office:body>
+</office:document>
+'''.format(text)
+        p = self.vm.run(
+            'cat > "{}" && libreoffice --headless --convert-to pptx '
+            '--outdir . "{}" 2>&1'.format(source, source),
+            passio_popen=True)
+        (stdout, _) = p.communicate(presentation.encode())
+        if p.returncode != 0:
+            self.skipTest('failed to create test pptx: {}'.format(stdout))
+        self.vm.run('rm -f "{}"'.format(source), wait=True)
+
     def create_video(self, filename):
         '''Create a tiny video file from generated frames
 
@@ -480,7 +517,27 @@ with zipfile.ZipFile(filename, "w") as ods:
         self.assertEqual(self.vm.run(
             'diff "orig.ods" "QubesUntrustedPDFs/test.ods"', wait=True), 0)
 
-    def test_009_video(self):
+    def test_009_pptx(self):
+        if self.vm.run('command -v libreoffice >/dev/null', wait=True) != 0:
+            self.skipTest('libreoffice not installed')
+        self.create_pptx('test.pptx', 'This is test')
+        p = self.vm.run(
+            'cp test.pptx orig.pptx; qvm-convert-file test.pptx 2>&1',
+            passio_popen=True)
+        (stdout, _) = p.communicate()
+        self.assertEqual(
+            p.returncode, 0, 'qvm-convert-file failed: {}'.format(stdout))
+        self.assertEqual(
+            self.vm.run('test -r "test.trusted.pdf"', wait=True), 0)
+        trusted_info = self.get_pdfinfo('test.trusted.pdf')
+        self.assertGreaterEqual(int(trusted_info['Pages']), 1)
+
+        self.assertEqual(
+            self.vm.run('test -r "QubesUntrustedPDFs/test.pptx"', wait=True), 0)
+        self.assertEqual(self.vm.run(
+            'diff "orig.pptx" "QubesUntrustedPDFs/test.pptx"', wait=True), 0)
+
+    def test_010_video(self):
         if self.vm.run('command -v ffmpeg >/dev/null', wait=True) != 0:
             self.skipTest('ffmpeg not installed')
         self.create_video('test.mp4')

--- a/qubespdfconverter/tests/test_password.py
+++ b/qubespdfconverter/tests/test_password.py
@@ -135,6 +135,15 @@ class TC_ServerPassword(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(renderer.resolution, 200)
         self.assertEqual(renderer.suffix, ".odt")
 
+    def test_create_renderer_returns_pptx_renderer(self):
+        """The server dispatch table creates the PPTX renderer."""
+        with tempfile.NamedTemporaryFile(suffix=".pptx") as f:
+            renderer = create_renderer("pptx", Path(f.name), resolution=200)
+
+        self.assertIsInstance(renderer, LibreOfficeDocumentRenderer)
+        self.assertEqual(renderer.resolution, 200)
+        self.assertEqual(renderer.suffix, ".pptx")
+
     def test_create_renderer_returns_ods_renderer(self):
         """The server dispatch table creates the ODS renderer."""
         with tempfile.NamedTemporaryFile(suffix=".ods") as f:
@@ -201,6 +210,21 @@ class TC_ServerPassword(unittest.IsolatedAsyncioTestCase):
             renderer_name = renderer_name_for_path(Path(f.name))
 
         self.assertEqual(renderer_name, "odt")
+
+    def test_server_dispatches_pptx_mime_to_pptx_renderer_name(self):
+        """PPTX MIME detection selects the shared document renderer."""
+        mime_type = (
+            "application/vnd.openxmlformats-officedocument."
+            "presentationml.presentation"
+        )
+
+        with tempfile.NamedTemporaryFile(suffix=".pptx") as f, mock.patch(
+            "qubespdfconverter.server.detect_mime",
+            return_value=mime_type,
+        ):
+            renderer_name = renderer_name_for_path(Path(f.name))
+
+        self.assertEqual(renderer_name, "pptx")
 
     def test_server_dispatches_ods_mime_to_ods_renderer_name(self):
         """ODS MIME detection selects the shared document renderer."""
@@ -306,6 +330,27 @@ class TC_ServerPassword(unittest.IsolatedAsyncioTestCase):
             def fake_run(cmd, capture_output, check):
                 if cmd[0] == "libreoffice":
                     self.assertEqual(Path(cmd[-1]).suffix, ".odt")
+                    Path(cmd[-1]).with_suffix(".pdf").write_bytes(b"%PDF-1.7")
+                    return mock.Mock(stdout=b"")
+
+                self.assertEqual(cmd[0], "pdfinfo")
+                return mock.Mock(stdout=b"Pages:           2\n")
+
+            with mock.patch("subprocess.run", side_effect=fake_run):
+                self.assertEqual(renderer.page_count(), 2)
+
+    def test_pptx_renderer_uses_pptx_extension_for_libreoffice(self):
+        """PPTX rendering uses the shared LibreOffice path with a PPTX input."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir, "source.pptx")
+            path.write_bytes(b"pptx")
+            renderer = LibreOfficeDocumentRenderer(
+                path, resolution=200, suffix=".pptx"
+            )
+
+            def fake_run(cmd, capture_output, check):
+                if cmd[0] == "libreoffice":
+                    self.assertEqual(Path(cmd[-1]).suffix, ".pptx")
                     Path(cmd[-1]).with_suffix(".pdf").write_bytes(b"%PDF-1.7")
                     return mock.Mock(stdout=b"")
 


### PR DESCRIPTION
Adds PPTX support to `qvm-convert-file` through the existing LibreOffice renderer. MIME detection stays on the server side, and presentations follow the same PDF-to-pixels path as the other office formats.

This also adds unit coverage, a Qubes integration test, and updates the supported-format list in the README.

Validation:
- `PYTHONPATH=. python qubespdfconverter/tests/test_password.py`
- `python -m py_compile qubespdfconverter/server.py qubespdfconverter/tests/test_password.py qubespdfconverter/tests/integ.py`
- `python -m pylint --rcfile=.pylintrc qubespdfconverter/server.py qubespdfconverter/tests/test_password.py`
- `git diff --check`