### PR TITLE
pdf-converter: add ODP presentation conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Usage
 
 The generic `qvm-convert-file` command also supports LibreOffice-backed
 document, spreadsheet, and presentation conversion for DOCX, ODT, XLSX, ODS,
-and PPTX files. Those formats require LibreOffice to be installed in the
+PPTX, and ODP files. Those formats require LibreOffice to be installed in the
 relevant template. It also supports common video formats by re-encoding them
 to `.trusted.ogv` with FFmpeg, when FFmpeg is installed in the relevant
 template. Video data crosses the qrexec boundary as raw RGB frames; audio is

--- a/qubespdfconverter/server.py
+++ b/qubespdfconverter/server.py
@@ -325,6 +325,7 @@ class VideoRenderer:
 
 RENDERERS = {
     "docx": functools.partial(LibreOfficeDocumentRenderer, suffix=".docx"),
+    "odp": functools.partial(LibreOfficeDocumentRenderer, suffix=".odp"),
     "ods": functools.partial(LibreOfficeDocumentRenderer, suffix=".ods"),
     "odt": functools.partial(LibreOfficeDocumentRenderer, suffix=".odt"),
     "pdf": PdfRenderer,
@@ -336,6 +337,7 @@ RENDERERS = {
 MIME_DISPATCH = {
     "application/pdf": "pdf",
     "application/vnd.openxmlformats-officedocument.wordprocessingml.document": ("docx"),
+    "application/vnd.oasis.opendocument.presentation": "odp",
     "application/vnd.oasis.opendocument.spreadsheet": "ods",
     "application/vnd.oasis.opendocument.text": "odt",
     "application/vnd.openxmlformats-officedocument.presentationml.presentation": (

--- a/qubespdfconverter/tests/integ.py
+++ b/qubespdfconverter/tests/integ.py
@@ -281,12 +281,13 @@ with zipfile.ZipFile(filename, "w") as ods:
         if p.returncode != 0:
             self.skipTest('failed to create test ods: {}'.format(stdout))
 
-    def create_pptx(self, filename, text):
-        '''Create PPTX file with given (textual) content
+    def create_presentation(self, filename, text):
+        '''Create a presentation file with given (textual) content
 
         :param filename: output filename
         :param text: text to be placed in the presentation
         '''
+        output_format = filename.rsplit('.', 1)[1]
         source = filename.rsplit('.', 1)[0] + '.fodp'
         presentation = '''<?xml version="1.0" encoding="UTF-8"?>
 <office:document
@@ -310,12 +311,13 @@ with zipfile.ZipFile(filename, "w") as ods:
 </office:document>
 '''.format(text)
         p = self.vm.run(
-            'cat > "{}" && libreoffice --headless --convert-to pptx '
-            '--outdir . "{}" 2>&1'.format(source, source),
+            'cat > "{}" && libreoffice --headless --convert-to {} '
+            '--outdir . "{}" 2>&1'.format(source, output_format, source),
             passio_popen=True)
         (stdout, _) = p.communicate(presentation.encode())
         if p.returncode != 0:
-            self.skipTest('failed to create test pptx: {}'.format(stdout))
+            self.skipTest(
+                'failed to create test {}: {}'.format(output_format, stdout))
         self.vm.run('rm -f "{}"'.format(source), wait=True)
 
     def create_video(self, filename):
@@ -520,7 +522,7 @@ with zipfile.ZipFile(filename, "w") as ods:
     def test_009_pptx(self):
         if self.vm.run('command -v libreoffice >/dev/null', wait=True) != 0:
             self.skipTest('libreoffice not installed')
-        self.create_pptx('test.pptx', 'This is test')
+        self.create_presentation('test.pptx', 'This is test')
         p = self.vm.run(
             'cp test.pptx orig.pptx; qvm-convert-file test.pptx 2>&1',
             passio_popen=True)
@@ -537,7 +539,27 @@ with zipfile.ZipFile(filename, "w") as ods:
         self.assertEqual(self.vm.run(
             'diff "orig.pptx" "QubesUntrustedPDFs/test.pptx"', wait=True), 0)
 
-    def test_010_video(self):
+    def test_010_odp(self):
+        if self.vm.run('command -v libreoffice >/dev/null', wait=True) != 0:
+            self.skipTest('libreoffice not installed')
+        self.create_presentation('test.odp', 'This is test')
+        p = self.vm.run(
+            'cp test.odp orig.odp; qvm-convert-file test.odp 2>&1',
+            passio_popen=True)
+        (stdout, _) = p.communicate()
+        self.assertEqual(
+            p.returncode, 0, 'qvm-convert-file failed: {}'.format(stdout))
+        self.assertEqual(
+            self.vm.run('test -r "test.trusted.pdf"', wait=True), 0)
+        trusted_info = self.get_pdfinfo('test.trusted.pdf')
+        self.assertGreaterEqual(int(trusted_info['Pages']), 1)
+
+        self.assertEqual(
+            self.vm.run('test -r "QubesUntrustedPDFs/test.odp"', wait=True), 0)
+        self.assertEqual(self.vm.run(
+            'diff "orig.odp" "QubesUntrustedPDFs/test.odp"', wait=True), 0)
+
+    def test_011_video(self):
         if self.vm.run('command -v ffmpeg >/dev/null', wait=True) != 0:
             self.skipTest('ffmpeg not installed')
         self.create_video('test.mp4')

--- a/qubespdfconverter/tests/test_password.py
+++ b/qubespdfconverter/tests/test_password.py
@@ -135,6 +135,15 @@ class TC_ServerPassword(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(renderer.resolution, 200)
         self.assertEqual(renderer.suffix, ".odt")
 
+    def test_create_renderer_returns_odp_renderer(self):
+        """The server dispatch table creates the ODP renderer."""
+        with tempfile.NamedTemporaryFile(suffix=".odp") as f:
+            renderer = create_renderer("odp", Path(f.name), resolution=200)
+
+        self.assertIsInstance(renderer, LibreOfficeDocumentRenderer)
+        self.assertEqual(renderer.resolution, 200)
+        self.assertEqual(renderer.suffix, ".odp")
+
     def test_create_renderer_returns_pptx_renderer(self):
         """The server dispatch table creates the PPTX renderer."""
         with tempfile.NamedTemporaryFile(suffix=".pptx") as f:
@@ -210,6 +219,18 @@ class TC_ServerPassword(unittest.IsolatedAsyncioTestCase):
             renderer_name = renderer_name_for_path(Path(f.name))
 
         self.assertEqual(renderer_name, "odt")
+
+    def test_server_dispatches_odp_mime_to_odp_renderer_name(self):
+        """ODP MIME detection selects the shared document renderer."""
+        mime_type = "application/vnd.oasis.opendocument.presentation"
+
+        with tempfile.NamedTemporaryFile(suffix=".odp") as f, mock.patch(
+            "qubespdfconverter.server.detect_mime",
+            return_value=mime_type,
+        ):
+            renderer_name = renderer_name_for_path(Path(f.name))
+
+        self.assertEqual(renderer_name, "odp")
 
     def test_server_dispatches_pptx_mime_to_pptx_renderer_name(self):
         """PPTX MIME detection selects the shared document renderer."""
@@ -351,6 +372,27 @@ class TC_ServerPassword(unittest.IsolatedAsyncioTestCase):
             def fake_run(cmd, capture_output, check):
                 if cmd[0] == "libreoffice":
                     self.assertEqual(Path(cmd[-1]).suffix, ".pptx")
+                    Path(cmd[-1]).with_suffix(".pdf").write_bytes(b"%PDF-1.7")
+                    return mock.Mock(stdout=b"")
+
+                self.assertEqual(cmd[0], "pdfinfo")
+                return mock.Mock(stdout=b"Pages:           2\n")
+
+            with mock.patch("subprocess.run", side_effect=fake_run):
+                self.assertEqual(renderer.page_count(), 2)
+
+    def test_odp_renderer_uses_odp_extension_for_libreoffice(self):
+        """ODP rendering uses the shared LibreOffice path with an ODP input."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir, "source.odp")
+            path.write_bytes(b"odp")
+            renderer = LibreOfficeDocumentRenderer(
+                path, resolution=200, suffix=".odp"
+            )
+
+            def fake_run(cmd, capture_output, check):
+                if cmd[0] == "libreoffice":
+                    self.assertEqual(Path(cmd[-1]).suffix, ".odp")
                     Path(cmd[-1]).with_suffix(".pdf").write_bytes(b"%PDF-1.7")
                     return mock.Mock(stdout=b"")
 


### PR DESCRIPTION
Adds ODP support to `qvm-convert-file` using the same LibreOffice path as PPTX. MIME detection stays on the server side.

I reused the presentation test setup for both formats and added ODP unit and integration coverage. The README format list is updated too.

Tested with:
- `PYTHONPATH=. python qubespdfconverter/tests/test_password.py`
- `python -m py_compile qubespdfconverter/server.py qubespdfconverter/tests/test_password.py qubespdfconverter/tests/integ.py`
- `python -m pylint --rcfile=.pylintrc qubespdfconverter/server.py qubespdfconverter/tests/test_password.py`
- `git diff --check`